### PR TITLE
Store the infected file log details as S3 objects for Security

### DIFF
--- a/src/python/api/v2/database_util/file.py
+++ b/src/python/api/v2/database_util/file.py
@@ -3,6 +3,7 @@
 from asyncpg import Connection, ForeignKeyViolationError
 from typing import List, Optional, Dict, Any
 from uuid import UUID
+import json
 import structlog
 from datetime import datetime, timezone
 
@@ -11,7 +12,7 @@ logger = structlog.get_logger(__name__)
 # --- FUNCTION ADDED: Restored the function needed by the upload process ---
 async def create_file_and_status_records(
     conn: Connection, file_id: UUID, file_name: str, file_type: str, user_id: UUID,
-    size_bytes: int, collection_id: UUID, collection_path: Optional[str], checksum: str
+    size_bytes: int, collection_id: UUID, collection_path: Optional[str], checksum: str, ip_address: Dict 
 ):
     """Atomically creates a file and its initial 'unscanned' file_status record in a transaction."""
     file_query = """
@@ -19,15 +20,15 @@ async def create_file_and_status_records(
         VALUES ($1, $2, $3, $4, $5, $6, $7, FALSE, $8);
     """
     status_query = """
-        INSERT INTO file_status (id, status, upload_time)
-        VALUES ($1, 'unscanned', $2);
+        INSERT INTO file_status (id, status, upload_time, scan_results)
+        VALUES ($1, 'unscanned', $2, $3::jsonb);
     """
     # These are executed within a transaction in the calling utils function
     await conn.execute(
         file_query, file_id, file_name, file_type, user_id, size_bytes,
         collection_id, collection_path, checksum
     )
-    await conn.execute(status_query, file_id, datetime.now(timezone.utc))
+    await conn.execute(status_query, file_id, datetime.now(timezone.utc), json.dumps(ip_address))
 
 
 async def get_file_details(conn: Connection, file_id: UUID) -> Optional[Dict[str, Any]]:

--- a/src/python/api/v2/utils/upload.py
+++ b/src/python/api/v2/utils/upload.py
@@ -82,13 +82,15 @@ async def prepare_single_file_upload(request: Request, params: PrepareUploadRequ
 async def complete_single_file_upload(
     request: Request, params: CompleteUploadRequest, user: AuthUser
 ) -> UUID:
+    ip_address = {"ip_address": request.client.host}
     async with request.state.pool.acquire() as conn:
         collection = await _validate_upload_permissions(request, params.collection_name, user)
         async with conn.transaction():
             await file_db.create_file_and_status_records(
                 conn=conn, file_id=params.file_id, file_name=params.file_name,
                 file_type=params.content_type, user_id=user.id, size_bytes=params.file_size_bytes,
-                collection_id=collection['id'], collection_path=params.collection_path, checksum=params.checksum
+                collection_id=collection['id'], collection_path=params.collection_path, checksum=params.checksum,
+                ip_address=ip_address 
             )
     logger.info("upload.single.completed", file_id=str(params.file_id))
     return params.file_id
@@ -126,6 +128,7 @@ async def get_multipart_presigned_url(params: MultipartGetPartUrlRequest) -> dic
 async def complete_multipart_upload(request: Request, params: MultipartCompleteRequest, user: AuthUser) -> UUID:
     s3_client = _get_s3_client()
     file_id = params.file_id
+    ip_address = {"ip_address": request.client.host}
     formatted_parts = [{'PartNumber': part.PartNumber, 'ETag': part.ETag} for part in params.parts]
     
     try:
@@ -141,9 +144,11 @@ async def complete_multipart_upload(request: Request, params: MultipartCompleteR
         collection = await _validate_upload_permissions(request, params.collection_name, user)
         async with conn.transaction():
             await file_db.create_file_and_status_records(
+
                 conn=conn, file_id=file_id, file_name=params.file_name,
                 file_type=params.content_type, user_id=user.id, size_bytes=params.final_file_size,
-                collection_id=collection['id'], collection_path=params.collection_path, checksum=params.checksum
+                collection_id=collection['id'], collection_path=params.collection_path, checksum=params.checksum,
+                ip_address=ip_address
             )
     logger.info("upload.multipart.completed", file_id=str(file_id))
     return file_id

--- a/src/python/event_lambdas/infected_logger/db.py
+++ b/src/python/event_lambdas/infected_logger/db.py
@@ -20,7 +20,7 @@ async def upsert_scan_status_in_database(conn: Connection, file_id: UUID, update
             status = EXCLUDED.status,
             scan_start = EXCLUDED.scan_start,
             scan_end = EXCLUDED.scan_end,
-            scan_results = EXCLUDED.scan_results
+            scan_results = COALESCE(file_status.scan_results, '[]'::jsonb) || EXCLUDED.scan_results
         RETURNING id;
     """
     try:


### PR DESCRIPTION
Added ip address to scan_results column during file upload confirmation.
Update upsert query in infected_logger/cue_scan_event to append and not overwrite scan_results.
This data will be captured by the age off glue job and stored in cue-<env>-archive bucket and will be queryable with Athena.
https://bugs.earthdata.nasa.gov/browse/CUE-163