### PR TITLE
Added Pagination support

### DIFF
--- a/src/python/api/v2/database_util/api_keys.py
+++ b/src/python/api/v2/database_util/api_keys.py
@@ -42,6 +42,8 @@ async def get_user_from_api_key(conn: Connection, key_hash: str) -> Optional[Dic
 async def list_api_keys(
     conn: Connection,
     requesting_user: Dict[str, Any],
+    page_size: int,
+    offset: int,
     active_ngroup_id: Optional[UUID] = None
 ) -> List[Dict[str, Any]]:
     """
@@ -76,10 +78,15 @@ async def list_api_keys(
             # For any other user (Manager, Staff, etc.), if no DAAC is selected,
             # they see an empty list. This forces a DAAC context to be chosen.
             where_conditions.append("1=0")  # A condition that is always false.
+    
+    limit_param = len(params) + 1
+    offset_param = len(params) + 2
+
+    params.extend([page_size, offset])
 
     where_clause = f"WHERE {' AND '.join(where_conditions)}"
     order_clause = "ORDER BY ak.created_at DESC;"
-    query = f"{base_query} {where_clause} {order_clause}"
+    query = f"{base_query} {where_clause} {order_clause} LIMIT ${limit_param} OFFSET ${offset_param}"
     
     # Added logging to help debug why the list might be empty.
     logger.info(
@@ -122,3 +129,43 @@ async def record_key_usage(conn: Connection, key_id: UUID) -> bool:
     query = "UPDATE api_key SET last_used_at = NOW() WHERE id = $1 RETURNING id;"
     result = await conn.fetchval(query, key_id)
     return result is not None
+
+async def count_api_keys(
+    conn: Connection,
+    requesting_user: Dict[str, Any],
+    active_ngroup_id: Optional[UUID] = None
+) -> int:
+    """
+    Returns the total number of API keys matching the same filters used
+    in list_api_keys(), for pagination support.
+    """
+    user_roles = set(requesting_user.get('roles', []))
+    params = []
+    where_conditions = ["ak.revoked_at IS NULL"]
+
+    if active_ngroup_id:
+        where_conditions.append("ak.ngroup_id = $1")
+        params.append(active_ngroup_id)
+    else:
+        if 'admin' in user_roles or 'security' in user_roles:
+            pass 
+        else:
+            where_conditions.append("1=0") 
+
+    where_clause = f"WHERE {' AND '.join(where_conditions)}"
+
+    count_query = f"""
+        SELECT COUNT(*)
+        FROM api_key ak
+        {where_clause};
+    """
+
+    logger.info(
+        "api_keys.count.executing_query",
+        user_roles=list(user_roles),
+        active_ngroup_id=str(active_ngroup_id) if active_ngroup_id else None,
+        final_where_clause=where_clause
+    )
+
+    result = await conn.fetchval(count_query, *params)
+    return result if result else 0

--- a/src/python/api/v2/database_util/api_keys.py
+++ b/src/python/api/v2/database_util/api_keys.py
@@ -42,8 +42,6 @@ async def get_user_from_api_key(conn: Connection, key_hash: str) -> Optional[Dic
 async def list_api_keys(
     conn: Connection,
     requesting_user: Dict[str, Any],
-    page_size: int,
-    offset: int,
     active_ngroup_id: Optional[UUID] = None
 ) -> List[Dict[str, Any]]:
     """
@@ -78,15 +76,10 @@ async def list_api_keys(
             # For any other user (Manager, Staff, etc.), if no DAAC is selected,
             # they see an empty list. This forces a DAAC context to be chosen.
             where_conditions.append("1=0")  # A condition that is always false.
-    
-    limit_param = len(params) + 1
-    offset_param = len(params) + 2
-
-    params.extend([page_size, offset])
 
     where_clause = f"WHERE {' AND '.join(where_conditions)}"
     order_clause = "ORDER BY ak.created_at DESC;"
-    query = f"{base_query} {where_clause} {order_clause} LIMIT ${limit_param} OFFSET ${offset_param}"
+    query = f"{base_query} {where_clause} {order_clause}"
     
     # Added logging to help debug why the list might be empty.
     logger.info(
@@ -129,43 +122,3 @@ async def record_key_usage(conn: Connection, key_id: UUID) -> bool:
     query = "UPDATE api_key SET last_used_at = NOW() WHERE id = $1 RETURNING id;"
     result = await conn.fetchval(query, key_id)
     return result is not None
-
-async def count_api_keys(
-    conn: Connection,
-    requesting_user: Dict[str, Any],
-    active_ngroup_id: Optional[UUID] = None
-) -> int:
-    """
-    Returns the total number of API keys matching the same filters used
-    in list_api_keys(), for pagination support.
-    """
-    user_roles = set(requesting_user.get('roles', []))
-    params = []
-    where_conditions = ["ak.revoked_at IS NULL"]
-
-    if active_ngroup_id:
-        where_conditions.append("ak.ngroup_id = $1")
-        params.append(active_ngroup_id)
-    else:
-        if 'admin' in user_roles or 'security' in user_roles:
-            pass 
-        else:
-            where_conditions.append("1=0") 
-
-    where_clause = f"WHERE {' AND '.join(where_conditions)}"
-
-    count_query = f"""
-        SELECT COUNT(*)
-        FROM api_key ak
-        {where_clause};
-    """
-
-    logger.info(
-        "api_keys.count.executing_query",
-        user_roles=list(user_roles),
-        active_ngroup_id=str(active_ngroup_id) if active_ngroup_id else None,
-        final_where_clause=where_clause
-    )
-
-    result = await conn.fetchval(count_query, *params)
-    return result if result else 0

--- a/src/python/api/v2/database_util/api_keys.py
+++ b/src/python/api/v2/database_util/api_keys.py
@@ -85,7 +85,7 @@ async def list_api_keys(
     params.extend([page_size, offset])
 
     where_clause = f"WHERE {' AND '.join(where_conditions)}"
-    order_clause = "ORDER BY ak.created_at DESC;"
+    order_clause = "ORDER BY ak.created_at DESC"
     query = f"{base_query} {where_clause} {order_clause} LIMIT ${limit_param} OFFSET ${offset_param}"
     
     # Added logging to help debug why the list might be empty.

--- a/src/python/api/v2/database_util/collection.py
+++ b/src/python/api/v2/database_util/collection.py
@@ -97,17 +97,37 @@ async def delete_collection(conn: Connection, collection_id: UUID) -> bool:
         logger.warning("db.collection.delete.failed_fk", collection_id=str(collection_id), error=str(e))
         raise ValueError("Cannot delete this collection because it is still linked to one or more files.") from e
 
-async def get_collection_count(conn: Connection, ngroup_id: int) -> int:
-    "Retrives the total Count of the collections, filtered by ngroup_id"
-    total_query = """
-        SELECT count(id) as total_count
-        FROM collection
-        WHERE ngroup_id = $1
-    """
+async def get_collection_count(conn: Connection, requesting_user: Dict[str, Any], active_ngroup_id: int) -> int:
+    "Retrives the total Count of the collection, filtered by ngroup_id"
+
+    logger.info(
+        "collection.count.executing_query",
+        user_roles=requesting_user.get('roles', []),
+        active_ngroup_id=str(active_ngroup_id) if active_ngroup_id else None
+    )
+
+    user_roles = set(requesting_user.get('roles', []))
+    params = []
+
+    # If a DAAC is selected, ALL roles are strictly filtered by it.
+    if active_ngroup_id:
+        where_clause = "WHERE ngroup_id = $1"
+        params.append(active_ngroup_id)
+    else:
+        # If NO DAAC is selected:
+        # Admins/Security see all providers from all groups.
+        if 'admin' in user_roles or 'security' in user_roles:
+            where_clause = ""  # No filter, show all
+        else:
+            # All other roles see an empty list if no DAAC is selected.
+            # This forces managers to select a DAAC to see its providers.
+            where_clause = "WHERE FALSE"  # Return no rows
+
     try:
-        total_row = await conn.fetchrow(total_query, ngroup_id)
+        query = f"SELECT count(id) FROM collection {where_clause}"
+        total_row = await conn.fetchrow(query)
         total_count = total_row["total_count"] if total_row else 0
         return total_count
     except Exception as e:
-        logger.error(f"Error fetching count: {e}", exc_info=True)
-        raise
+        logger.error(f"Error fetching count: {e}", error=str(e))
+        raise ValueError("Cannot fetch total count") from e

--- a/src/python/api/v2/database_util/collection.py
+++ b/src/python/api/v2/database_util/collection.py
@@ -35,7 +35,9 @@ async def get_collection_by_short_name(conn: Connection, short_name: str) -> Opt
 async def list_collections(
     conn: Connection,
     requesting_user: Dict[str, Any],
-    active_ngroup_id: Optional[UUID] = None
+    page_size: int,
+    offset: int,
+    active_ngroup_id: Optional[UUID] = None,
 ) -> List[Dict[str, Any]]:
     """
     Retrieves all collection records, filtered by the active ngroup and user role.
@@ -62,8 +64,13 @@ async def list_collections(
             # All other roles see an empty list if no DAAC is selected.
             # This forces managers to select a DAAC to see its collections.
             where_clause = "WHERE FALSE" # Return no rows
-            
-    query = f"SELECT * FROM collection {where_clause} ORDER BY short_name"
+
+    limit_param = len(params) + 1
+    offset_param = len(params) + 2
+
+    params.extend([page_size, offset])
+
+    query = f"SELECT * FROM collection {where_clause} ORDER BY short_name LIMIT ${limit_param} OFFSET ${offset_param}"
     return await conn.fetch(query, *params)
 
 async def update_collection(conn: Connection, collection_id: UUID, update_data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
@@ -89,3 +96,18 @@ async def delete_collection(conn: Connection, collection_id: UUID) -> bool:
     except ForeignKeyViolationError as e:
         logger.warning("db.collection.delete.failed_fk", collection_id=str(collection_id), error=str(e))
         raise ValueError("Cannot delete this collection because it is still linked to one or more files.") from e
+
+async def get_collection_count(conn: Connection, ngroup_id: int) -> int:
+    "Retrives the total Count of the collections, filtered by ngroup_id"
+    total_query = """
+        SELECT count(id) as total_count
+        FROM collection
+        WHERE ngroup_id = $1
+    """
+    try:
+        total_row = await conn.fetchrow(total_query, ngroup_id)
+        total_count = total_row["total_count"] if total_row else 0
+        return total_count
+    except Exception as e:
+        logger.error(f"Error fetching count: {e}", exc_info=True)
+        raise

--- a/src/python/api/v2/database_util/collection.py
+++ b/src/python/api/v2/database_util/collection.py
@@ -125,8 +125,8 @@ async def get_collection_count(conn: Connection, requesting_user: Dict[str, Any]
 
     try:
         query = f"SELECT count(id) FROM collection {where_clause}"
-        total_row = await conn.fetchrow(query)
-        total_count = total_row["total_count"] if total_row else 0
+        total_row = await conn.fetchrow(query, *params)
+        total_count = total_row["count"] if total_row else 0
         return total_count
     except Exception as e:
         logger.error(f"Error fetching count: {e}", error=str(e))

--- a/src/python/api/v2/database_util/collection.py
+++ b/src/python/api/v2/database_util/collection.py
@@ -53,7 +53,7 @@ async def list_collections(
     
     # If a DAAC is selected, ALL roles are strictly filtered by it.
     if active_ngroup_id:
-        where_clause = "WHERE ngroup_id = $1"
+        where_clause = "WHERE c.ngroup_id = $1"
         params.append(active_ngroup_id)
     else:
         # If NO DAAC is selected:
@@ -70,7 +70,26 @@ async def list_collections(
 
     params.extend([page_size, offset])
 
-    query = f"SELECT * FROM collection {where_clause} ORDER BY short_name LIMIT ${limit_param} OFFSET ${offset_param}"
+    query = f"""
+        SELECT
+            c.*,
+            jsonb_build_object(
+                'id', p.id,
+                'name', p.short_name
+            ) AS provider,
+            jsonb_build_object(
+                'id', e.id,
+                'path', e.path
+            ) AS egress
+        FROM collection c
+        LEFT JOIN provider p ON c.provider_id = p.id 
+        LEFT JOIN egress e ON c.egress_id = e.id
+        {where_clause}
+        ORDER BY c.short_name
+        LIMIT ${limit_param}
+        OFFSET ${offset_param}
+    """
+    
     return await conn.fetch(query, *params)
 
 async def update_collection(conn: Connection, collection_id: UUID, update_data: Dict[str, Any]) -> Optional[Dict[str, Any]]:

--- a/src/python/api/v2/database_util/cueuser.py
+++ b/src/python/api/v2/database_util/cueuser.py
@@ -48,6 +48,8 @@ async def get_user_by_id(conn: Connection, user_id: UUID) -> Optional[Dict[str, 
 async def list_users(
     conn: Connection,
     requesting_user: Dict[str, Any],
+    page_size: int,
+    offset: int,
     active_ngroup_id: Optional[UUID] = None
 ) -> List[Dict[str, Any]]:
     """
@@ -104,7 +106,13 @@ async def list_users(
             where_conditions.append("FALSE")
 
     where_clause = f"WHERE {' AND '.join(where_conditions)}" if where_conditions else ""
-    query = f"{base_query} {where_clause} ORDER BY u.name;"
+
+    limit_param = len(params) + 1
+    offset_param = len(params) + 2
+
+    params.extend([page_size, offset])
+
+    query = f"{base_query} {where_clause} ORDER BY u.name LIMIT ${limit_param} OFFSET ${offset_param};"
     
     return await conn.fetch(query, *params)
 
@@ -257,3 +265,54 @@ async def delete_user(conn: Connection, user_id: UUID) -> bool:
     result = await conn.execute("DELETE FROM cueuser WHERE id = $1", user_id)
     deleted_count = int(result.split(" ")[1])
     return deleted_count > 0
+
+async def get_users_count(
+    conn: Connection,
+    requesting_user: Dict[str, Any],
+    active_ngroup_id: Optional[UUID] = None
+) -> int:
+    """
+    Returns total count of users applying the same filters used in list_users().
+    """
+
+    logger.info(
+        "user.count.executing_query",
+        user_roles=requesting_user.get('roles', []),
+        active_ngroup_id=str(active_ngroup_id) if active_ngroup_id else None
+    )
+
+    user_roles = set(requesting_user.get('roles', []))
+    params = []
+    where_conditions = []
+
+    if active_ngroup_id:
+        # Filter only users in this DAAC
+        where_conditions.append(
+            "EXISTS (SELECT 1 FROM cueuser_ngroup ug WHERE ug.cueuser_id = u.id AND ug.ngroup_id = $1)"
+        )
+        params.append(active_ngroup_id)
+
+    else:
+        # No DAAC selected
+        if 'admin' not in user_roles and 'security' not in user_roles:
+            # Managers/other roles → see nothing
+            where_conditions.append("FALSE")
+
+    where_clause = (
+        f"WHERE {' AND '.join(where_conditions)}"
+        if where_conditions else ""
+    )
+
+    query = f"""
+        SELECT COUNT(*) AS total_count
+        FROM cueuser u
+        {where_clause};
+    """
+
+    try:
+        row = await conn.fetchrow(query, *params)
+        return row["total_count"] if row else 0
+
+    except Exception as e:
+        logger.error(f"Error fetching user count: {e}", error=str(e))
+        raise

--- a/src/python/api/v2/database_util/egress.py
+++ b/src/python/api/v2/database_util/egress.py
@@ -29,6 +29,8 @@ async def get_egress_by_id(conn: Connection, egress_id: UUID) -> Optional[Dict[s
 async def list_egresses(
     conn: Connection,
     requesting_user: Dict[str, Any],
+    page_size: int,
+    offset: int,
     active_ngroup_id: Optional[UUID] = None
 ) -> List[Dict[str, Any]]:
     """
@@ -56,8 +58,13 @@ async def list_egresses(
             # All other roles see an empty list if no DAAC is selected.
             # This forces managers to select a DAAC to see its egress targets.
             where_clause = "WHERE FALSE" # Return no rows
-            
-    query = f"SELECT * FROM egress {where_clause} ORDER BY type, path"
+
+    limit_param = len(params) + 1
+    offset_param = len(params) + 2
+
+    params.extend([page_size, offset])
+
+    query = f"SELECT * FROM egress {where_clause} ORDER BY type, path LIMIT ${limit_param} OFFSET ${offset_param}"
     return await conn.fetch(query, *params)
 
 async def update_egress(conn: Connection, egress_id: UUID, update_data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
@@ -81,3 +88,38 @@ async def delete_egress(conn: Connection, egress_id: UUID) -> bool:
     except ForeignKeyViolationError as e:
         logger.warning("db.egress.delete.failed_fk", egress_id=str(egress_id), error=str(e))
         raise ValueError("Cannot delete this egress target because it is still linked to one or more collections.") from e
+    
+async def get_egress_count(conn: Connection, requesting_user: Dict[str, Any], active_ngroup_id: int) -> int:
+    "Retrives the total Count of the providers, filtered by ngroup_id"
+
+    logger.info(
+        "egress.count.executing_query",
+        user_roles=requesting_user.get('roles', []),
+        active_ngroup_id=str(active_ngroup_id) if active_ngroup_id else None
+    )
+
+    user_roles = set(requesting_user.get('roles', []))
+    params = []
+
+    # If a DAAC is selected, ALL roles are strictly filtered by it.
+    if active_ngroup_id:
+        where_clause = "WHERE ngroup_id = $1"
+        params.append(active_ngroup_id)
+    else:
+        # If NO DAAC is selected:
+        # Admins/Security see all egress from all groups.
+        if 'admin' in user_roles or 'security' in user_roles:
+            where_clause = ""  # No filter, show all
+        else:
+            # All other roles see an empty list if no DAAC is selected.
+            # This forces managers to select a DAAC to see its egress.
+            where_clause = "WHERE FALSE"  # Return no rows
+
+    try:
+        query = f"SELECT count(id) FROM egress {where_clause}"
+        total_row = await conn.fetchrow(query,*params)
+        total_count = total_row["count"] if total_row else 0
+        return total_count
+    except Exception as e:
+        logger.error(f"Error fetching count: {e}", error=str(e))
+        raise ValueError("Cannot fetch total count") from e

--- a/src/python/api/v2/database_util/provider.py
+++ b/src/python/api/v2/database_util/provider.py
@@ -30,6 +30,8 @@ async def get_provider_by_id(conn: Connection, provider_id: UUID) -> Optional[Di
 async def list_providers(
     conn: Connection,
     requesting_user: Dict[str, Any],
+    page_size: int,
+    offset: int,
     active_ngroup_id: Optional[UUID] = None
 ) -> List[Dict[str, Any]]:
     """
@@ -57,8 +59,13 @@ async def list_providers(
             # All other roles see an empty list if no DAAC is selected.
             # This forces managers to select a DAAC to see its providers.
             where_clause = "WHERE FALSE"  # Return no rows
+    
+    limit_param = len(params) + 1
+    offset_param = len(params) + 2
 
-    query = f"SELECT * FROM provider {where_clause} ORDER BY short_name"
+    params.extend([page_size, offset])
+
+    query = f"SELECT * FROM provider {where_clause} ORDER BY short_name LIMIT ${limit_param} OFFSET ${offset_param}"
     return await conn.fetch(query, *params)
 
 async def list_providers_for_form(conn: Connection, ngroup_id: UUID) -> List[Dict[str, Any]]:
@@ -89,3 +96,38 @@ async def delete_provider(conn: Connection, provider_id: UUID) -> bool:
     except ForeignKeyViolationError as e:
         logger.warning("db.provider.delete.failed_fk", provider_id=str(provider_id), error=str(e))
         raise ValueError("Cannot delete this provider because it is still linked to one or more collections.") from e
+    
+async def get_providers_count(conn: Connection, requesting_user: Dict[str, Any], active_ngroup_id: int) -> int:
+    "Retrives the total Count of the providers, filtered by ngroup_id"
+
+    logger.info(
+        "provider.count.executing_query",
+        user_roles=requesting_user.get('roles', []),
+        active_ngroup_id=str(active_ngroup_id) if active_ngroup_id else None
+    )
+
+    user_roles = set(requesting_user.get('roles', []))
+    params = []
+
+    # If a DAAC is selected, ALL roles are strictly filtered by it.
+    if active_ngroup_id:
+        where_clause = "WHERE ngroup_id = $1"
+        params.append(active_ngroup_id)
+    else:
+        # If NO DAAC is selected:
+        # Admins/Security see all providers from all groups.
+        if 'admin' in user_roles or 'security' in user_roles:
+            where_clause = ""  # No filter, show all
+        else:
+            # All other roles see an empty list if no DAAC is selected.
+            # This forces managers to select a DAAC to see its providers.
+            where_clause = "WHERE FALSE"  # Return no rows
+
+    try:
+        query = f"SELECT count(id) FROM provider {where_clause}"
+        total_row = await conn.fetchrow(query)
+        total_count = total_row["total_count"] if total_row else 0
+        return total_count
+    except Exception as e:
+        logger.error(f"Error fetching count: {e}", error=str(e))
+        raise ValueError("Cannot fetch total count") from e

--- a/src/python/api/v2/database_util/provider.py
+++ b/src/python/api/v2/database_util/provider.py
@@ -125,8 +125,8 @@ async def get_providers_count(conn: Connection, requesting_user: Dict[str, Any],
 
     try:
         query = f"SELECT count(id) FROM provider {where_clause}"
-        total_row = await conn.fetchrow(query)
-        total_count = total_row["total_count"] if total_row else 0
+        total_row = await conn.fetchrow(query,*params)
+        total_count = total_row["count"] if total_row else 0
         return total_count
     except Exception as e:
         logger.error(f"Error fetching count: {e}", error=str(e))

--- a/src/python/api/v2/database_util/provider.py
+++ b/src/python/api/v2/database_util/provider.py
@@ -32,6 +32,7 @@ async def list_providers(
     requesting_user: Dict[str, Any],
     page_size: int,
     offset: int,
+    can_upload: bool,
     active_ngroup_id: Optional[UUID] = None
 ) -> List[Dict[str, Any]]:
     """
@@ -59,6 +60,17 @@ async def list_providers(
             # All other roles see an empty list if no DAAC is selected.
             # This forces managers to select a DAAC to see its providers.
             where_clause = "WHERE FALSE"  # Return no rows
+    
+    can_upload_param = len(params) + 1
+    if can_upload is not None:
+        #test where class with empty string
+        if where_clause:
+            where_clause = f"{where_clause} AND can_upload = ${can_upload_param}"
+            params.append(can_upload)
+        
+        else:
+            where_clause = f"WHERE can_upload = ${can_upload_param}"
+            params.append(can_upload)
     
     limit_param = len(params) + 1
     offset_param = len(params) + 2
@@ -110,7 +122,7 @@ async def delete_provider(conn: Connection, provider_id: UUID) -> bool:
         logger.warning("db.provider.delete.failed_fk", provider_id=str(provider_id), error=str(e))
         raise ValueError("Cannot delete this provider because it is still linked to one or more collections.") from e
     
-async def get_providers_count(conn: Connection, requesting_user: Dict[str, Any], active_ngroup_id: int) -> int:
+async def get_providers_count(conn: Connection, requesting_user: Dict[str, Any], active_ngroup_id: int, can_upload: bool) -> int:
     "Retrives the total Count of the providers, filtered by ngroup_id"
 
     logger.info(
@@ -135,6 +147,17 @@ async def get_providers_count(conn: Connection, requesting_user: Dict[str, Any],
             # All other roles see an empty list if no DAAC is selected.
             # This forces managers to select a DAAC to see its providers.
             where_clause = "WHERE FALSE"  # Return no rows
+    
+    can_upload_param = len(params) + 1
+    if can_upload is not None:
+        #test where class with empty string
+        if where_clause:
+            where_clause = f"{where_clause} AND can_upload = ${can_upload_param}"
+            params.append(can_upload)
+        
+        else:
+            where_clause = f"where can_upload = ${can_upload_param}"
+            params.append(can_upload)
 
     try:
         query = f"SELECT count(id) FROM provider {where_clause}"

--- a/src/python/api/v2/database_util/provider.py
+++ b/src/python/api/v2/database_util/provider.py
@@ -65,7 +65,20 @@ async def list_providers(
 
     params.extend([page_size, offset])
 
-    query = f"SELECT * FROM provider {where_clause} ORDER BY short_name LIMIT ${limit_param} OFFSET ${offset_param}"
+    query = f"""
+        SELECT
+            p.*,
+            jsonb_build_object(
+                'id', u.id,
+                'name', u.name
+            ) AS point_of_contact
+        FROM provider p
+        LEFT JOIN cueuser u ON p.point_of_contact = u.id
+        {where_clause}
+        ORDER BY p.short_name
+        LIMIT ${limit_param}
+        OFFSET ${offset_param}
+    """
     return await conn.fetch(query, *params)
 
 async def list_providers_for_form(conn: Connection, ngroup_id: UUID) -> List[Dict[str, Any]]:

--- a/src/python/api/v2/endpoints/api_keys.py
+++ b/src/python/api/v2/endpoints/api_keys.py
@@ -1,14 +1,14 @@
 # ==============================================================================
 # File: src/python/api/v2/endpoints/api_keys.py
 # ==============================================================================
-from fastapi import APIRouter, Depends, HTTPException, status, Request, Header, Query
+from fastapi import APIRouter, Depends, HTTPException, status, Request, Header
 from uuid import UUID
 from typing import List, Optional
 
 from core.security import get_current_user, require_privilege
 from v2.type_util.auth import AuthUser
 from v2.utils import api_keys as api_key_utils
-from v2.type_util.api_keys import ApiKeyCreateRequest, ApiKeyCreateResponse, ApiKeyUpdateRequest, PaginatedAPIKeyResponse
+from v2.type_util.api_keys import ApiKeyCreateRequest, ApiKeyCreateResponse, ApiKeyInfo, ApiKeyUpdateRequest
 
 router = APIRouter(prefix="/api-keys", tags=["V2 - API Keys"])
 
@@ -25,14 +25,12 @@ async def create_api_key_endpoint(fastapi_request: Request, request_body: ApiKey
     except Exception as e:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e))
 
-@router.get("/", response_model=PaginatedAPIKeyResponse, dependencies=[Depends(require_privilege("api-key:read"))])
+@router.get("/", response_model=List[ApiKeyInfo], dependencies=[Depends(require_privilege("api-key:read"))])
 async def list_api_keys_endpoint(
     request: Request, 
     user: AuthUser = Depends(get_current_user),
     # 1. reads the active DAAC/group ID from the HTTP header.
-    active_ngroup_id: Optional[str] = Header(None, alias="x-active-ngroup-id"),
-    page: int = Query(1, ge=1),
-    page_size: int = Query(50, ge=1, le=100)
+    active_ngroup_id: Optional[str] = Header(None, alias="x-active-ngroup-id")
 ):
     """
     Lists API keys filtered by the user's active DAAC/ngroup.
@@ -40,7 +38,7 @@ async def list_api_keys_endpoint(
     """
     try:
         # 2. The active_ngroup_id is now passed down to the business logic layer.
-        return await api_key_utils.list_api_keys(request, user, page, page_size, active_ngroup_id)
+        return await api_key_utils.list_api_keys(request, user, active_ngroup_id)
     except Exception as e:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e))
 

--- a/src/python/api/v2/endpoints/api_keys.py
+++ b/src/python/api/v2/endpoints/api_keys.py
@@ -1,14 +1,14 @@
 # ==============================================================================
 # File: src/python/api/v2/endpoints/api_keys.py
 # ==============================================================================
-from fastapi import APIRouter, Depends, HTTPException, status, Request, Header
+from fastapi import APIRouter, Depends, HTTPException, status, Request, Header, Query
 from uuid import UUID
 from typing import List, Optional
 
 from core.security import get_current_user, require_privilege
 from v2.type_util.auth import AuthUser
 from v2.utils import api_keys as api_key_utils
-from v2.type_util.api_keys import ApiKeyCreateRequest, ApiKeyCreateResponse, ApiKeyInfo, ApiKeyUpdateRequest
+from v2.type_util.api_keys import ApiKeyCreateRequest, ApiKeyCreateResponse, ApiKeyUpdateRequest, PaginatedAPIKeyResponse
 
 router = APIRouter(prefix="/api-keys", tags=["V2 - API Keys"])
 
@@ -25,12 +25,14 @@ async def create_api_key_endpoint(fastapi_request: Request, request_body: ApiKey
     except Exception as e:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e))
 
-@router.get("/", response_model=List[ApiKeyInfo], dependencies=[Depends(require_privilege("api-key:read"))])
+@router.get("/", response_model=PaginatedAPIKeyResponse, dependencies=[Depends(require_privilege("api-key:read"))])
 async def list_api_keys_endpoint(
     request: Request, 
     user: AuthUser = Depends(get_current_user),
     # 1. reads the active DAAC/group ID from the HTTP header.
-    active_ngroup_id: Optional[str] = Header(None, alias="x-active-ngroup-id")
+    active_ngroup_id: Optional[str] = Header(None, alias="x-active-ngroup-id"),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=100)
 ):
     """
     Lists API keys filtered by the user's active DAAC/ngroup.
@@ -38,7 +40,7 @@ async def list_api_keys_endpoint(
     """
     try:
         # 2. The active_ngroup_id is now passed down to the business logic layer.
-        return await api_key_utils.list_api_keys(request, user, active_ngroup_id)
+        return await api_key_utils.list_api_keys(request, user, page, page_size, active_ngroup_id)
     except Exception as e:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e))
 

--- a/src/python/api/v2/endpoints/collection.py
+++ b/src/python/api/v2/endpoints/collection.py
@@ -39,7 +39,7 @@ async def list_collections_endpoint(
     #  Read the active ngroup ID directly from the header
     active_ngroup_id: Optional[str] = Header(None, alias="x-active-ngroup-id"),
     page: int = Query(1, ge=1),
-    page_size: int = Query(50, ge=1, le=100)
+    page_size: int = Query(50, ge=1, le=50)
 ):
     """Retrieves all collections, filtered by the user's active ngroup from the header."""
     if "admin" not in user.roles and not user.active_ngroup_id:

--- a/src/python/api/v2/endpoints/collection.py
+++ b/src/python/api/v2/endpoints/collection.py
@@ -1,14 +1,14 @@
 # ==============================================================================
 # File: src/python/api/v2/endpoints/collection.py
 # ==============================================================================
-from fastapi import APIRouter, Depends, HTTPException, status, Request, Header 
+from fastapi import APIRouter, Depends, HTTPException, status, Request, Header, Query
 from uuid import UUID
 from typing import List, Optional
 
 from core.security import get_current_user, require_privilege
 from v2.type_util.auth import AuthUser
 from v2.utils import collection as collection_utils
-from v2.type_util.collection import CollectionCreate, CollectionUpdate, CollectionResponse
+from v2.type_util.collection import CollectionCreate, CollectionUpdate, CollectionResponse,PaginatedCollectionResponse
 
 router = APIRouter(prefix="/collections", tags=["V2 - Collections"])
 
@@ -32,12 +32,14 @@ async def create_collection_endpoint(
     except Exception as e:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e))
 
-@router.get("/", response_model=List[CollectionResponse], dependencies=[Depends(require_privilege("collection:read"))])
+@router.get("/", response_model=PaginatedCollectionResponse, dependencies=[Depends(require_privilege("collection:read"))])
 async def list_collections_endpoint(
     request: Request,
     user: AuthUser = Depends(get_current_user),
     #  Read the active ngroup ID directly from the header
-    active_ngroup_id: Optional[str] = Header(None, alias="x-active-ngroup-id")
+    active_ngroup_id: Optional[str] = Header(None, alias="x-active-ngroup-id"),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=100)
 ):
     """Retrieves all collections, filtered by the user's active ngroup from the header."""
     if "admin" not in user.roles and not user.active_ngroup_id:
@@ -45,7 +47,7 @@ async def list_collections_endpoint(
     
     try:
         # Pass the header value and the user object to the utility function
-        return await collection_utils.list_collections(request, user, active_ngroup_id)
+        return await collection_utils.list_collections(request, user, active_ngroup_id, page, page_size)
     except Exception as e:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e))
 

--- a/src/python/api/v2/endpoints/cueuser.py
+++ b/src/python/api/v2/endpoints/cueuser.py
@@ -28,7 +28,7 @@ async def list_users_endpoint(
     # Read the active ngroup ID directly from the header
     active_ngroup_id: Optional[str] = Header(None, alias="x-active-ngroup-id"),
     page: int = Query(1, ge=1),
-    page_size: int = Query(50, ge=1, le=100)
+    page_size: int = Query(50, ge=1, le=50)
 ):
     """Retrieves a list of all users, filtered by the active DAAC."""
     try:

--- a/src/python/api/v2/endpoints/cueuser.py
+++ b/src/python/api/v2/endpoints/cueuser.py
@@ -8,7 +8,7 @@ from typing import List, Optional
 from core.security import get_current_user, require_privilege
 from v2.type_util.auth import AuthUser as User
 from v2.utils import cueuser as cueuser_utils
-from v2.type_util.cueuser import UserResponse, UserCreateRequest, UserUpdateRequest, UserFindResponse, UserRoleUpdateRequest
+from v2.type_util.cueuser import UserResponse, UserCreateRequest, UserUpdateRequest, UserFindResponse, UserRoleUpdateRequest, PaginatedUserResponse
 
 router = APIRouter(prefix="/cueusers", tags=["V2 - CUE Users"])
 
@@ -21,18 +21,20 @@ async def get_my_profile(request: Request, user: User = Depends(get_current_user
     except cueuser_utils.UserNotFoundError:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User profile not found in database.")
 
-@router.get("/", response_model=List[UserResponse], dependencies=[Depends(require_privilege("user:read"))])
+@router.get("/", response_model=PaginatedUserResponse, dependencies=[Depends(require_privilege("user:read"))])
 async def list_users_endpoint(
     request: Request,
     user: User = Depends(get_current_user),
     # Read the active ngroup ID directly from the header
-    active_ngroup_id: Optional[str] = Header(None, alias="x-active-ngroup-id")
+    active_ngroup_id: Optional[str] = Header(None, alias="x-active-ngroup-id"),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=100)
 ):
     """Retrieves a list of all users, filtered by the active DAAC."""
     try:
         # Pass the header value and the current user to the utility function
-        users = await cueuser_utils.list_users(request, user, active_ngroup_id)
-        return [UserResponse.model_validate(u) for u in users]
+        users = await cueuser_utils.list_users(request, user, active_ngroup_id, page, page_size)
+        return PaginatedUserResponse.model_validate(users)
     except Exception as e:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e))
 

--- a/src/python/api/v2/endpoints/egress.py
+++ b/src/python/api/v2/endpoints/egress.py
@@ -37,7 +37,7 @@ async def list_egresses_endpoint(
     # Read the active ngroup ID directly from the header
     active_ngroup_id: Optional[str] = Header(None, alias="x-active-ngroup-id"),
     page: int = Query(1, ge=1),
-    page_size: int = Query(50, ge=1, le=100)
+    page_size: int = Query(50, ge=1, le=50)
 ):
     """Retrieves all egress records, filtered by the user's active ngroup from the header."""
     try:

--- a/src/python/api/v2/endpoints/egress.py
+++ b/src/python/api/v2/endpoints/egress.py
@@ -1,14 +1,14 @@
 # ==============================================================================
 # File: src/python/api/v2/endpoints/egress.py (Corrected)
 # ==============================================================================
-from fastapi import APIRouter, Depends, HTTPException, status, Request, Header
+from fastapi import APIRouter, Depends, HTTPException, status, Request, Header, Query
 from uuid import UUID
 from typing import List, Optional
 
 from core.security import get_current_user, require_privilege
 from v2.type_util.auth import AuthUser
 from v2.utils import egress as egress_utils
-from v2.type_util.egress import EgressCreate, EgressUpdate, EgressResponse
+from v2.type_util.egress import EgressCreate, EgressUpdate, EgressResponse, PaginatedEgressResponse
 
 router = APIRouter(prefix="/egress", tags=["V2 - DAAC Egress"])
 
@@ -30,17 +30,19 @@ async def create_egress_endpoint(
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
-@router.get("/", response_model=List[EgressResponse], dependencies=[Depends(require_privilege("egress:read"))])
+@router.get("/", response_model=PaginatedEgressResponse, dependencies=[Depends(require_privilege("egress:read"))])
 async def list_egresses_endpoint(
     request: Request, 
     user: AuthUser = Depends(get_current_user),
     # Read the active ngroup ID directly from the header
-    active_ngroup_id: Optional[str] = Header(None, alias="x-active-ngroup-id")
+    active_ngroup_id: Optional[str] = Header(None, alias="x-active-ngroup-id"),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=100)
 ):
     """Retrieves all egress records, filtered by the user's active ngroup from the header."""
     try:
         # Pass the header value and the user object to the utility function
-        return await egress_utils.list_egresses(request, user, active_ngroup_id)
+        return await egress_utils.list_egresses(request, user, active_ngroup_id,page, page_size)
     except Exception as e:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e))
 

--- a/src/python/api/v2/endpoints/provider.py
+++ b/src/python/api/v2/endpoints/provider.py
@@ -47,7 +47,7 @@ async def list_providers_endpoint(
     # Read the active ngroup ID directly from the header
     active_ngroup_id: Optional[str] = Header(None, alias="x-active-ngroup-id"),
     page: int = Query(1, ge=1),
-    page_size: int = Query(50, ge=1, le=100)
+    page_size: int = Query(50, ge=1, le=50)
 ):
     """
     Retrieves all provider records, filtered by the user's selected ngroup from the header.

--- a/src/python/api/v2/endpoints/provider.py
+++ b/src/python/api/v2/endpoints/provider.py
@@ -47,14 +47,15 @@ async def list_providers_endpoint(
     # Read the active ngroup ID directly from the header
     active_ngroup_id: Optional[str] = Header(None, alias="x-active-ngroup-id"),
     page: int = Query(1, ge=1),
-    page_size: int = Query(50, ge=1, le=50)
+    page_size: int = Query(50, ge=1, le=50),
+    can_upload: bool = Query(None, description="Filter by can_upload status")
 ):
     """
     Retrieves all provider records, filtered by the user's selected ngroup from the header.
     """
     try:
         # Pass the header value and the user object to the utility function
-        return await provider_utils.list_providers(request, user, active_ngroup_id, page, page_size)
+        return await provider_utils.list_providers(request, user, active_ngroup_id, page, page_size, can_upload)
     except Exception as e:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e))
 

--- a/src/python/api/v2/endpoints/provider.py
+++ b/src/python/api/v2/endpoints/provider.py
@@ -9,7 +9,7 @@ from core.security import require_privilege, get_current_user
 from v2.type_util.auth import AuthUser
 from v2.utils import provider as provider_utils
 from v2.type_util.provider import (
-    ProviderCreate, ProviderUpdate, ProviderResponse, ProviderListResponse
+    ProviderCreate, ProviderUpdate, ProviderResponse, ProviderListResponse, PaginatedProviderResponse
 )
 
 router = APIRouter(prefix="/providers", tags=["V2 - Providers"])
@@ -40,19 +40,21 @@ async def list_providers_for_application_form(
     except Exception as e:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Could not retrieve providers for the application form.")
 
-@router.get("/", response_model=List[ProviderResponse], dependencies=[Depends(require_privilege("provider:read"))])
+@router.get("/", response_model=PaginatedProviderResponse, dependencies=[Depends(require_privilege("provider:read"))])
 async def list_providers_endpoint(
     request: Request,
     user: AuthUser = Depends(get_current_user),
     # Read the active ngroup ID directly from the header
-    active_ngroup_id: Optional[str] = Header(None, alias="x-active-ngroup-id")
+    active_ngroup_id: Optional[str] = Header(None, alias="x-active-ngroup-id"),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=100)
 ):
     """
     Retrieves all provider records, filtered by the user's selected ngroup from the header.
     """
     try:
         # Pass the header value and the user object to the utility function
-        return await provider_utils.list_providers(request, user, active_ngroup_id)
+        return await provider_utils.list_providers(request, user, active_ngroup_id, page, page_size)
     except Exception as e:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e))
 

--- a/src/python/api/v2/type_util/api_keys.py
+++ b/src/python/api/v2/type_util/api_keys.py
@@ -95,3 +95,9 @@ class ApiKeyInfo(BaseModel):
 
     class Config:
         from_attributes = True
+
+class PaginatedAPIKeyResponse(BaseModel):
+    api_keys: List[ApiKeyInfo]
+    page: int
+    page_size: int
+    total: int

--- a/src/python/api/v2/type_util/api_keys.py
+++ b/src/python/api/v2/type_util/api_keys.py
@@ -95,9 +95,3 @@ class ApiKeyInfo(BaseModel):
 
     class Config:
         from_attributes = True
-
-class PaginatedAPIKeyResponse(BaseModel):
-    api_keys: List[ApiKeyInfo]
-    page: int
-    page_size: int
-    total: int

--- a/src/python/api/v2/type_util/collection.py
+++ b/src/python/api/v2/type_util/collection.py
@@ -33,5 +33,5 @@ class CollectionResponse(CollectionBase):
         from_attributes = True
 
 class PaginatedCollectionResponse(BaseModel):
-    total_count: int
+    total: int
     collections: List[CollectionResponse]

--- a/src/python/api/v2/type_util/collection.py
+++ b/src/python/api/v2/type_util/collection.py
@@ -1,7 +1,7 @@
 # File: src/python/api/v2/type_util/collection.py
 
 from pydantic import BaseModel, Field
-from typing import Optional
+from typing import Optional,List
 from uuid import UUID
 
 class CollectionBase(BaseModel):
@@ -31,3 +31,7 @@ class CollectionResponse(CollectionBase):
 
     class Config:
         from_attributes = True
+
+class PaginatedCollectionResponse(BaseModel):
+    total_count: int
+    collections: List[CollectionResponse]

--- a/src/python/api/v2/type_util/collection.py
+++ b/src/python/api/v2/type_util/collection.py
@@ -33,5 +33,7 @@ class CollectionResponse(CollectionBase):
         from_attributes = True
 
 class PaginatedCollectionResponse(BaseModel):
-    total: int
     collections: List[CollectionResponse]
+    page: int
+    page_size: int
+    total: int

--- a/src/python/api/v2/type_util/collection.py
+++ b/src/python/api/v2/type_util/collection.py
@@ -32,8 +32,26 @@ class CollectionResponse(CollectionBase):
     class Config:
         from_attributes = True
 
+class Provider(BaseModel):
+    id: UUID
+    name: str
+
+class Egress(BaseModel):
+    id: UUID
+    path: str
+
+class CollectionListResponse(CollectionBase):
+    """Model for returning a full collection object from the API."""
+    id: UUID
+    ngroup_id: UUID
+    provider: Provider
+    egress: Egress
+
+    class Config:
+        from_attributes = True
+
 class PaginatedCollectionResponse(BaseModel):
-    collections: List[CollectionResponse]
+    collections: List[CollectionListResponse]
     page: int
     page_size: int
     total: int

--- a/src/python/api/v2/type_util/cueuser.py
+++ b/src/python/api/v2/type_util/cueuser.py
@@ -57,3 +57,9 @@ class UserUpdateRequest(BaseModel):
 class UserRoleUpdateRequest(BaseModel):
     """Request body for updating a user's role."""
     role_id: UUID
+
+class PaginatedUserResponse(BaseModel):
+    users: List[UserResponse]
+    page: int
+    page_size: int
+    total: int

--- a/src/python/api/v2/type_util/egress.py
+++ b/src/python/api/v2/type_util/egress.py
@@ -29,7 +29,7 @@ class EgressResponse(EgressBase):
         from_attributes = True
 
 class PaginatedEgressResponse(BaseModel):
-    egress: List[EgressResponse]
+    egresses: List[EgressResponse]
     page: int
     page_size: int
     total: int

--- a/src/python/api/v2/type_util/egress.py
+++ b/src/python/api/v2/type_util/egress.py
@@ -1,7 +1,7 @@
 # File: src/python/api/v2/type_util/egress.py
 
 from pydantic import BaseModel, Field
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, List
 from uuid import UUID
 
 class EgressBase(BaseModel):
@@ -27,3 +27,9 @@ class EgressResponse(EgressBase):
 
     class Config:
         from_attributes = True
+
+class PaginatedEgressResponse(BaseModel):
+    egress: List[EgressResponse]
+    page: int
+    page_size: int
+    total: int

--- a/src/python/api/v2/type_util/provider.py
+++ b/src/python/api/v2/type_util/provider.py
@@ -3,7 +3,7 @@
 # Purpose: Defines Pydantic models for the v2 provider management endpoints.
 # ==============================================================================
 from pydantic import BaseModel
-from typing import Optional
+from typing import Optional, List
 from uuid import UUID
 
 class ProviderBase(BaseModel):
@@ -43,3 +43,7 @@ class ProviderListResponse(BaseModel):
 
     class Config:
         from_attributes = True
+
+class PaginatedProviderResponse(BaseModel):
+    total: int
+    providers: List[ProviderResponse]

--- a/src/python/api/v2/type_util/provider.py
+++ b/src/python/api/v2/type_util/provider.py
@@ -44,8 +44,22 @@ class ProviderListResponse(BaseModel):
     class Config:
         from_attributes = True
 
+class PointOfContactUser(BaseModel):
+    id: UUID
+    name: str
+
+class ProviderUserResponse(ProviderBase):
+    """Model for returning a full provider object from the API."""
+    id: UUID
+    ngroup_id: UUID
+    point_of_contact: PointOfContactUser
+    reason:  Optional[str] = None
+
+    class Config:
+        from_attributes = True
+
 class PaginatedProviderResponse(BaseModel):
-    providers: List[ProviderResponse]
+    providers: List[ProviderUserResponse]
     page: int
     page_size: int
     total: int

--- a/src/python/api/v2/type_util/provider.py
+++ b/src/python/api/v2/type_util/provider.py
@@ -45,5 +45,7 @@ class ProviderListResponse(BaseModel):
         from_attributes = True
 
 class PaginatedProviderResponse(BaseModel):
-    total: int
     providers: List[ProviderResponse]
+    page: int
+    page_size: int
+    total: int

--- a/src/python/api/v2/utils/api_keys.py
+++ b/src/python/api/v2/utils/api_keys.py
@@ -103,35 +103,18 @@ async def create_api_key(request: Request, create_body: ApiKeyCreateRequest, cre
     return {"id": key_id, "name": create_body.name, "key": raw_key}
 
 # Simplified to pass the full user object to the database layer.
-async def list_api_keys(request: Request, user: AuthUser, page: int, page_size: int, active_ngroup_id: Optional[str] = None) -> Dict[str, Any]:
+async def list_api_keys(request: Request, user: AuthUser, active_ngroup_id: Optional[str] = None) -> List[ApiKeyInfo]:
     """Retrieves API keys based on the user's role and active ngroup from the header."""
-    offset = (page - 1) * page_size
     async with request.state.pool.acquire() as conn:
         # Convert the string ID from the header to a UUID object for the database function
         active_ngroup_uuid = UUID(active_ngroup_id) if active_ngroup_id else None
-
-        total = await api_key_db.count_api_keys(
-            conn=conn, 
-            requesting_user=user.model_dump(), 
-            active_ngroup_id=active_ngroup_uuid,
-            )
-        result = []
-        if total > 0:
-            keys_data = await api_key_db.list_api_keys(
-                conn,
-                requesting_user=user.model_dump(),
-                active_ngroup_id=active_ngroup_uuid,
-                page_size = page_size,
-                offset = offset
-            )
-            result = [dict(r) for r in keys_data]
-            
-    return {
-        "api_keys": result,
-        "page": page,
-        "page_size": page_size,
-        "total": total,
-    }
+        
+        keys_data = await api_key_db.list_api_keys(
+            conn,
+            requesting_user=user.model_dump(),
+            active_ngroup_id=active_ngroup_uuid
+        )
+    return [ApiKeyInfo.model_validate(dict(key)) for key in keys_data]
 
 # Permission check now includes an override for admin/security roles.
 async def update_api_key(request: Request, key_id: UUID, update_request: ApiKeyUpdateRequest, user: AuthUser):

--- a/src/python/api/v2/utils/api_keys.py
+++ b/src/python/api/v2/utils/api_keys.py
@@ -103,18 +103,35 @@ async def create_api_key(request: Request, create_body: ApiKeyCreateRequest, cre
     return {"id": key_id, "name": create_body.name, "key": raw_key}
 
 # Simplified to pass the full user object to the database layer.
-async def list_api_keys(request: Request, user: AuthUser, active_ngroup_id: Optional[str] = None) -> List[ApiKeyInfo]:
+async def list_api_keys(request: Request, user: AuthUser, page: int, page_size: int, active_ngroup_id: Optional[str] = None) -> Dict[str, Any]:
     """Retrieves API keys based on the user's role and active ngroup from the header."""
+    offset = (page - 1) * page_size
     async with request.state.pool.acquire() as conn:
         # Convert the string ID from the header to a UUID object for the database function
         active_ngroup_uuid = UUID(active_ngroup_id) if active_ngroup_id else None
-        
-        keys_data = await api_key_db.list_api_keys(
-            conn,
-            requesting_user=user.model_dump(),
-            active_ngroup_id=active_ngroup_uuid
-        )
-    return [ApiKeyInfo.model_validate(dict(key)) for key in keys_data]
+
+        total = await api_key_db.count_api_keys(
+            conn=conn, 
+            requesting_user=user.model_dump(), 
+            active_ngroup_id=active_ngroup_uuid,
+            )
+        result = []
+        if total > 0:
+            keys_data = await api_key_db.list_api_keys(
+                conn,
+                requesting_user=user.model_dump(),
+                active_ngroup_id=active_ngroup_uuid,
+                page_size = page_size,
+                offset = offset
+            )
+            result = [dict(r) for r in keys_data]
+            
+    return {
+        "api_keys": result,
+        "page": page,
+        "page_size": page_size,
+        "total": total,
+    }
 
 # Permission check now includes an override for admin/security roles.
 async def update_api_key(request: Request, key_id: UUID, update_request: ApiKeyUpdateRequest, user: AuthUser):

--- a/src/python/api/v2/utils/collection.py
+++ b/src/python/api/v2/utils/collection.py
@@ -68,7 +68,9 @@ async def list_collections(
             result = [dict(r) for r in records]
     return {
         "total": total,
-        "collections": result
+        "collections": result,
+        "page": page,
+        "page_size": page_size
     }
 
 

--- a/src/python/api/v2/utils/collection.py
+++ b/src/python/api/v2/utils/collection.py
@@ -4,6 +4,7 @@
 from uuid import UUID
 from typing import List, Dict, Any, Optional, Tuple
 import structlog
+import json
 from fastapi import Request 
 from v2.database_util import collection as collection_db
 from v2.database_util import provider as provider_db
@@ -65,7 +66,17 @@ async def list_collections(
                 page_size=page_size, offset=offset,
                 active_ngroup_id=ngroup_id_to_filter
             )
-            result = [dict(r) for r in records]
+            for r in records:
+                row = dict(r)
+
+                # convert jsonb string to dict
+                if isinstance(row.get("provider"), str):
+                    row["provider"] = json.loads(row["provider"])
+
+                if isinstance(row.get("egress"), str):
+                    row["egress"] = json.loads(row["egress"])
+
+                result.append(row)
     return {
         "total": total,
         "collections": result,

--- a/src/python/api/v2/utils/collection.py
+++ b/src/python/api/v2/utils/collection.py
@@ -47,7 +47,7 @@ async def list_collections(
     user: AuthUser, # Accept the full user object for role checks
     active_ngroup_id: Optional[str], # Accept the optional ngroup ID string
     page: int, page_size: int
-) -> Tuple[int, List[Dict[str, Any]]]:
+) -> Dict[str, Any]:
     """Retrieves all collection records based on the user's roles and active ngroup."""
     
     # Convert string UUID from header to UUID object, or None
@@ -66,7 +66,10 @@ async def list_collections(
                 active_ngroup_id=ngroup_id_to_filter
             )
             result = [dict(r) for r in records]
-    return total,result
+    return {
+        "total": total,
+        "collections": result
+    }
 
 
 async def update_collection(

--- a/src/python/api/v2/utils/collection.py
+++ b/src/python/api/v2/utils/collection.py
@@ -57,7 +57,7 @@ async def list_collections(
     async with request.state.pool.acquire() as conn:
         # Call the new, more powerful list_collections function
         result = []
-        total = await collection_db.get_collection_count(conn, ngroup_id_to_filter)
+        total = await collection_db.get_collection_count(conn = conn, requesting_user=user.model_dump(), active_ngroup_id=ngroup_id_to_filter)
         if total > 0:
             records = await collection_db.list_collections(
                 conn, 

--- a/src/python/api/v2/utils/collection.py
+++ b/src/python/api/v2/utils/collection.py
@@ -2,7 +2,7 @@
 # File: src/python/api/v2/utils/collection.py
 # ==============================================================================
 from uuid import UUID
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any, Optional, Tuple
 import structlog
 from fastapi import Request 
 from v2.database_util import collection as collection_db
@@ -45,20 +45,28 @@ async def get_collection(request: Request, collection_id: UUID) -> Dict[str, Any
 async def list_collections(
     request: Request,
     user: AuthUser, # Accept the full user object for role checks
-    active_ngroup_id: Optional[str] # Accept the optional ngroup ID string
-) -> List[Dict[str, Any]]:
+    active_ngroup_id: Optional[str], # Accept the optional ngroup ID string
+    page: int, page_size: int
+) -> Tuple[int, List[Dict[str, Any]]]:
     """Retrieves all collection records based on the user's roles and active ngroup."""
     
     # Convert string UUID from header to UUID object, or None
     ngroup_id_to_filter = UUID(active_ngroup_id) if active_ngroup_id else None
-    
+
+    offset = (page - 1) * page_size
     async with request.state.pool.acquire() as conn:
-        records = await collection_db.list_collections(
-            conn, 
-            requesting_user=user.model_dump(),
-            active_ngroup_id=ngroup_id_to_filter
-        )
-    return [dict(r) for r in records]
+        # Call the new, more powerful list_collections function
+        result = []
+        total = await collection_db.get_collection_count(conn, ngroup_id_to_filter)
+        if total > 0:
+            records = await collection_db.list_collections(
+                conn, 
+                requesting_user=user.model_dump(),
+                page_size=page_size, offset=offset,
+                active_ngroup_id=ngroup_id_to_filter
+            )
+            result = [dict(r) for r in records]
+    return total,result
 
 
 async def update_collection(

--- a/src/python/api/v2/utils/cueuser.py
+++ b/src/python/api/v2/utils/cueuser.py
@@ -85,20 +85,37 @@ async def get_user_profile(request: Request, user_id: UUID) -> Dict[str, Any]:
 async def list_users(
     request: Request,
     current_user: AuthUser, # Accept the full user object for role checks
-    active_ngroup_id: Optional[str] # Accept the optional ngroup ID string
-) -> List[Dict[str, Any]]:
+    active_ngroup_id: Optional[str], # Accept the optional ngroup ID string
+    page: int, page_size: int
+) -> Dict[str, Any]:
     """Retrieves a list of all users, filtered by the active DAAC and user role."""
     
     # Convert string UUID from header to UUID object, or None
     ngroup_id_to_filter = UUID(active_ngroup_id) if active_ngroup_id else None
     
+    offset = (page - 1) * page_size
     async with request.state.pool.acquire() as conn:
-        users_data = await user_db.list_users(
-            conn,
-            requesting_user=current_user.model_dump(),
-            active_ngroup_id=ngroup_id_to_filter
-        )
-    return [_parse_user_data(user) for user in users_data]
+        total = await user_db.get_users_count(
+            conn=conn, 
+            requesting_user=current_user.model_dump(), 
+            active_ngroup_id=ngroup_id_to_filter,
+            )
+        result = []
+        if total > 0:
+            users_data = await user_db.list_users(
+                conn,
+                requesting_user=current_user.model_dump(),
+                active_ngroup_id=ngroup_id_to_filter,
+                page_size = page_size,
+                offset = offset
+            )
+            result = [_parse_user_data(user) for user in users_data]
+    return {
+        "users": result,
+        "page": page,
+        "page_size": page_size,
+        "total": total,
+    }
 
 async def get_user_profile_by_username(request: Request, cueusername: str) -> Dict[str, Any]:
     """Fetches and parses a user's complete profile by their username."""

--- a/src/python/api/v2/utils/egress.py
+++ b/src/python/api/v2/utils/egress.py
@@ -45,21 +45,38 @@ async def get_egress(request: Request, egress_id: UUID) -> Dict[str, Any]:
 async def list_egresses(
     request: Request,
     user: AuthUser, # Accept the full user object for role checks
-    active_ngroup_id: Optional[str] # Accept the optional ngroup ID string
-) -> List[Dict[str, Any]]:
+    active_ngroup_id: Optional[str], # Accept the optional ngroup ID string
+    page: int, page_size: int
+) -> Dict[str, Any]:
     """Retrieves all egress records based on the user's roles and active ngroup."""
     
     # Convert string UUID from header to UUID object, or None
     ngroup_id_to_filter = UUID(active_ngroup_id) if active_ngroup_id else None
     
+    offset = (page - 1) * page_size
     async with request.state.pool.acquire() as conn:
         # Call the new, more powerful list_egresses function
-        records = await egress_db.list_egresses(
-            conn,
-            requesting_user=user.model_dump(),
-            active_ngroup_id=ngroup_id_to_filter
-        )
-    return [_process_record(dict(r)) for r in records]
+        total = await egress_db.get_egress_count(
+            conn=conn, 
+            requesting_user=user.model_dump(), 
+            active_ngroup_id=ngroup_id_to_filter,
+            )
+        result = []
+        if total > 0:
+            records = await egress_db.list_egresses(
+                conn,
+                requesting_user=user.model_dump(),
+                active_ngroup_id=ngroup_id_to_filter,
+                page_size = page_size,
+                offset = offset
+            )
+            result = [_process_record(dict(r)) for r in records]
+    return {
+        "total": total,
+        "egress": result,
+        "page": page,
+        "page_size": page_size
+    }
 
 async def update_egress(request: Request, egress_id: UUID, egress_update: EgressUpdate) -> Dict[str, Any]:
     """Updates an existing egress record."""

--- a/src/python/api/v2/utils/egress.py
+++ b/src/python/api/v2/utils/egress.py
@@ -73,7 +73,7 @@ async def list_egresses(
             result = [_process_record(dict(r)) for r in records]
     return {
         "total": total,
-        "egress": result,
+        "egresses": result,
         "page": page,
         "page_size": page_size
     }

--- a/src/python/api/v2/utils/provider.py
+++ b/src/python/api/v2/utils/provider.py
@@ -80,7 +80,9 @@ async def list_providers(
             result = [dict(r) for r in records]
     return {
         "total": total,
-        "providers": result
+        "providers": result,
+        "page": page,
+        "page_size": page_size
     }
 
 async def list_providers_for_form(request: Request, ngroup_id: UUID) -> List[Dict[str, Any]]:

--- a/src/python/api/v2/utils/provider.py
+++ b/src/python/api/v2/utils/provider.py
@@ -2,7 +2,7 @@
 # File: src/python/api/v2/utils/provider.py 
 # ==============================================================================
 from uuid import UUID
-from typing import List, Optional, Dict, Any
+from typing import List, Optional, Dict, Any, Tuple
 from v2.type_util.auth import AuthUser
 import structlog
 from fastapi import Request
@@ -51,21 +51,34 @@ async def get_provider(request: Request, provider_id: UUID) -> Dict[str, Any]:
 async def list_providers(
     request: Request,
     user: AuthUser, # Accept the full user object for role checks
-    active_ngroup_id: Optional[str] # Accept the optional ngroup ID string
-) -> List[Dict[str, Any]]:
+    active_ngroup_id: Optional[str], # Accept the optional ngroup ID string
+    page: int, page_size: int
+) -> Tuple[int, List[Dict[str, Any]]]:
     """Retrieves all provider records based on the user's roles and active ngroup."""
 
     # Convert string UUID from header to UUID object, or None
     ngroup_id_to_filter = UUID(active_ngroup_id) if active_ngroup_id else None
 
+    offset = (page - 1) * page_size
     async with request.state.pool.acquire() as conn:
         # Call list_providers function
-        records = await provider_db.list_providers(
-            conn,
-            requesting_user=user.model_dump(),
-            active_ngroup_id=ngroup_id_to_filter
-        )
-    return [dict(r) for r in records]
+
+        total = await provider_db.get_providers_count(
+            conn=conn, 
+            requesting_user=user.model_dump(), 
+            active_ngroup_id=ngroup_id_to_filter,
+            )
+        result = []
+        if total > 0:
+            records = await provider_db.list_providers(
+                conn,
+                requesting_user=user.model_dump(),
+                active_ngroup_id=ngroup_id_to_filter,
+                page_size = page_size,
+                offset = offset
+            )
+            result = [dict(r) for r in records]
+    return total, result
 
 async def list_providers_for_form(request: Request, ngroup_id: UUID) -> List[Dict[str, Any]]:
     """Retrieves a simplified list of providers for a given ngroup."""

--- a/src/python/api/v2/utils/provider.py
+++ b/src/python/api/v2/utils/provider.py
@@ -6,6 +6,7 @@ from typing import List, Optional, Dict, Any, Tuple
 from v2.type_util.auth import AuthUser
 import structlog
 from fastapi import Request
+import json
 
 
 from v2.database_util import provider as provider_db
@@ -77,7 +78,14 @@ async def list_providers(
                 page_size = page_size,
                 offset = offset
             )
-            result = [dict(r) for r in records]
+            for r in records:
+                row = dict(r)
+
+                # convert jsonb string to dict
+                if isinstance(row.get("point_of_contact"), str):
+                    row["point_of_contact"] = json.loads(row["point_of_contact"])
+
+                result.append(row)
     return {
         "total": total,
         "providers": result,

--- a/src/python/api/v2/utils/provider.py
+++ b/src/python/api/v2/utils/provider.py
@@ -53,7 +53,7 @@ async def list_providers(
     user: AuthUser, # Accept the full user object for role checks
     active_ngroup_id: Optional[str], # Accept the optional ngroup ID string
     page: int, page_size: int
-) -> Tuple[int, List[Dict[str, Any]]]:
+) -> Dict[str, Any]:
     """Retrieves all provider records based on the user's roles and active ngroup."""
 
     # Convert string UUID from header to UUID object, or None
@@ -78,7 +78,10 @@ async def list_providers(
                 offset = offset
             )
             result = [dict(r) for r in records]
-    return total, result
+    return {
+        "total": total,
+        "providers": result
+    }
 
 async def list_providers_for_form(request: Request, ngroup_id: UUID) -> List[Dict[str, Any]]:
     """Retrieves a simplified list of providers for a given ngroup."""

--- a/src/python/api/v2/utils/provider.py
+++ b/src/python/api/v2/utils/provider.py
@@ -53,7 +53,8 @@ async def list_providers(
     request: Request,
     user: AuthUser, # Accept the full user object for role checks
     active_ngroup_id: Optional[str], # Accept the optional ngroup ID string
-    page: int, page_size: int
+    page: int, page_size: int,
+    can_upload: bool
 ) -> Dict[str, Any]:
     """Retrieves all provider records based on the user's roles and active ngroup."""
 
@@ -68,6 +69,7 @@ async def list_providers(
             conn=conn, 
             requesting_user=user.model_dump(), 
             active_ngroup_id=ngroup_id_to_filter,
+            can_upload = can_upload
             )
         result = []
         if total > 0:
@@ -76,7 +78,8 @@ async def list_providers(
                 requesting_user=user.model_dump(),
                 active_ngroup_id=ngroup_id_to_filter,
                 page_size = page_size,
-                offset = offset
+                offset = offset,
+                can_upload = can_upload
             )
             for r in records:
                 row = dict(r)


### PR DESCRIPTION
Added Pagination support to Users, collections, Egress and Providers.

Changes:
1. added query to fetch total count 
2. Added page number and page size in request param
3. Now fetch the rows based on the offset and page size
4. Added joins for the dependency data 
> Collections : Added provider and Egress Joins based on the provider and egress id
>  Provider: Added user join based on the user id
5. Max Api response count limited to 50
https://bugs.earthdata.nasa.gov/browse/CUE-283