### PR TITLE
Feature: Search with GIN Trigram

### DIFF
--- a/src/postgres/2-tables.sql
+++ b/src/postgres/2-tables.sql
@@ -291,3 +291,6 @@ CREATE INDEX IF NOT EXISTS idx_provider_ngroup_id ON provider(ngroup_id);
 CREATE INDEX IF NOT EXISTS idx_file_status_pending_notification
 ON file_status(status)
 WHERE (status = 'infected' AND notification_sent_at IS NULL);
+
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+CREATE INDEX IF NOT EXISTS idx_file_name_trgm ON file USING gin (name gin_trgm_ops);

--- a/src/postgres/9-updates.sql
+++ b/src/postgres/9-updates.sql
@@ -134,3 +134,6 @@ COMMIT;
 -- CREATE INDEX IF NOT EXISTS idx_file_status_pending_notification
 -- ON file_status(status)
 -- WHERE (status = 'infected' AND notification_sent_at IS NULL);
+
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_file_name_trgm ON file USING gin (name gin_trgm_ops);

--- a/src/python/api/v2/database_util/file.py
+++ b/src/python/api/v2/database_util/file.py
@@ -250,6 +250,51 @@ async def find_files_by_name(
     return await conn.fetch(query, *params)
 
 
+async def search_files_by_name(
+    conn: Connection,
+    requesting_user: Dict[str, Any],
+    active_ngroup_id: Optional[UUID],
+    partial_file_name: str,
+    limit: int,
+    offset: int,
+    status: Optional[str] = None
+) -> List[Dict[str, Any]]:
+    """Searches files by partial name using pg_trgm-backed ILIKE matching."""
+    user_roles = set(requesting_user.get('roles', []))
+    params: list[Any] = [f"%{partial_file_name}%"]
+
+    base_query = """
+        SELECT
+            f.id, f.name, f.type, f.cueuser_uploaded, f.size_bytes, f.collection_id, c.short_name AS collection_name,
+            f.collection_path, f.checksum,
+            fs.status, fs.upload_time, fs.scan_results, fs.egress_start
+        FROM file f
+        JOIN collection c ON f.collection_id = c.id
+        LEFT JOIN file_status fs ON f.id = fs.id
+    """
+    where_conditions = ["f.name != 'pending_upload'", "f.name ILIKE $1"]
+
+    if active_ngroup_id:
+        params.append(active_ngroup_id)
+        where_conditions.append(f"c.ngroup_id = ${len(params)}")
+    else:
+        if 'admin' not in user_roles and 'security' not in user_roles:
+            where_conditions.append("FALSE")
+
+    if status:
+        params.append(status)
+        where_conditions.append(f"fs.status = ${len(params)}")
+
+    query = f"""
+        {base_query}
+        WHERE {' AND '.join(where_conditions)}
+        ORDER BY similarity(f.name, ${len(params) + 1}) DESC, fs.upload_time DESC
+        LIMIT ${len(params) + 2} OFFSET ${len(params) + 3};
+    """
+    params.extend([partial_file_name, limit, offset])
+    return await conn.fetch(query, *params)
+
+
 async def delete_file(conn: Connection, file_id: UUID) -> bool:
     """Deletes a file record. Assumes ON DELETE CASCADE is set for related tables."""
     try:

--- a/src/python/api/v2/endpoints/file.py
+++ b/src/python/api/v2/endpoints/file.py
@@ -8,7 +8,7 @@ from typing import List, Optional
 from core.security import get_current_user, require_privilege
 from v2.type_util.auth import AuthUser
 from v2.utils import file as file_utils
-from v2.type_util.file import FileResponse, PaginatedFileResponse, FileUpdateRequest, FileListRequest 
+from v2.type_util.file import FileResponse, PaginatedFileResponse, FileSearchResponse, FileUpdateRequest, FileListRequest 
 from v2.utils.authorization import check_user_access_to_file
 from datetime import date
 
@@ -73,6 +73,25 @@ async def find_files_by_name_endpoint(
         return await file_utils.find_files_by_name(request, user, active_ngroup_id, name)
     except Exception as e:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Error finding files: {e}")
+
+@router.get("/search", response_model=FileSearchResponse, dependencies=[Depends(require_privilege("file:read"))])
+async def search_files_by_name_endpoint(
+    request: Request,
+    q: str = Query(..., min_length=1, description="Partial file name to search for."),
+    file_status: Optional[str] = Query(None, alias="status", description="Optional file status filter."),
+    page: int = Query(1, ge=1, description="Page number."),
+    page_size: int = Query(10, ge=1, le=100, description="Items per page."),
+    user: AuthUser = Depends(get_current_user),
+    active_ngroup_id: Optional[str] = Header(None, alias="x-active-ngroup-id")
+):
+    """Searches file records by partial name within the selected ngroup."""
+    try:
+        items, has_more = await file_utils.search_files_by_name(
+            request, user, active_ngroup_id, q, page, page_size, file_status
+        )
+        return FileSearchResponse(items=items, has_more=has_more, page=page, page_size=page_size)
+    except Exception as e:
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Error searching files: {e}")
 
 @router.get("/{file_id}", response_model=FileResponse, dependencies=[Depends(require_privilege("file:read"))])
 async def get_file_endpoint(

--- a/src/python/api/v2/type_util/file.py
+++ b/src/python/api/v2/type_util/file.py
@@ -3,6 +3,10 @@ from typing import Optional, List, Dict, Any
 from uuid import UUID
 from datetime import datetime, date
 
+class FileCollectionResponse(BaseModel):
+    id: UUID
+    name: str
+
 class FileResponse(BaseModel):
     id: UUID
     name: str
@@ -10,6 +14,7 @@ class FileResponse(BaseModel):
     cueuser_uploaded: UUID
     size_bytes: int
     collection_id: UUID
+    collection: Optional[FileCollectionResponse] = None
     collection_path: Optional[str] = None
     checksum: str
     status: Optional[str] = None
@@ -25,6 +30,12 @@ class FileResponse(BaseModel):
 class PaginatedFileResponse(BaseModel):
     items: List[FileResponse]
     total: int
+    page: int
+    page_size: int
+
+class FileSearchResponse(BaseModel):
+    items: List[FileResponse]
+    has_more: bool
     page: int
     page_size: int
 

--- a/src/python/api/v2/utils/file.py
+++ b/src/python/api/v2/utils/file.py
@@ -60,6 +60,13 @@ def _process_record(record: Dict[str, Any]) -> Dict[str, Any]:
         processed_record['scan_results'] = scan_results
     else:
         processed_record['scan_results'] = None
+
+    collection_name = processed_record.pop('collection_name', None)
+    if collection_name:
+        processed_record['collection'] = {
+            'id': processed_record.get('collection_id'),
+            'name': collection_name
+        }
         
     return processed_record
 
@@ -87,6 +94,33 @@ async def find_files_by_name(
             file_name=file_name
         )
     return [_process_record(dict(r)) for r in records]
+
+async def search_files_by_name(
+    request: Request,
+    user: AuthUser,
+    active_ngroup_id: Optional[str],
+    partial_file_name: str,
+    page: int,
+    page_size: int,
+    status: Optional[str] = None
+) -> Tuple[List[Dict[str, Any]], bool]:
+    """Searches files by partial name within a specific ngroup, optionally by status."""
+    offset = (page - 1) * page_size
+    ngroup_id_to_filter = UUID(active_ngroup_id) if active_ngroup_id else None
+
+    async with request.state.pool.acquire() as conn:
+        user_dump = user.model_dump()
+        records = await file_db.search_files_by_name(
+            conn,
+            requesting_user=user_dump,
+            active_ngroup_id=ngroup_id_to_filter,
+            partial_file_name=partial_file_name,
+            limit=page_size + 1,
+            offset=offset,
+            status=status
+        )
+    has_more = len(records) > page_size
+    return [_process_record(dict(r)) for r in records[:page_size]], has_more
 
 async def list_files(
     request: Request,

--- a/tests/integration_tests/api_endpoint_tests/test_endpoints_file.py
+++ b/tests/integration_tests/api_endpoint_tests/test_endpoints_file.py
@@ -146,6 +146,68 @@ async def test_find_files_by_name_endpoint(test_client, test_admin_user, seed_fi
 
 
 @pytest.mark.asyncio
+async def test_search_files_by_name_endpoint(test_client, test_admin_user, seed_file, make_jwt, mock_boto3_client):
+    """Test search files by partial name endpoint - success."""
+    test_admin_user_jwt = make_jwt(sub=str(test_admin_user.id))
+    headers = {"Authorization": f"Bearer {test_admin_user_jwt}", "x-active-ngroup-id":test_admin_user.active_ngroup_id}
+    file_id1 = uuid.uuid4()
+    file_id2 = uuid.uuid4()
+    file_id3 = uuid.uuid4()
+    await seed_file(file_id1, "granule-alpha.nc", 'application/octet-stream', test_admin_user.id, 1024, status="distributed")
+    await seed_file(file_id2, "granule-beta.nc", 'application/octet-stream', test_admin_user.id, 1024, status="clean")
+    await seed_file(file_id3, "metadata.json", 'application/octet-stream', test_admin_user.id, 1024, status="distributed")
+    params = {"q": "gran", "page": 1, "page_size": 10}
+
+    response = test_client.get("/v2/files/search", headers=headers, params=params)
+    response_json = response.json()
+
+    assert response.status_code == 200
+    assert response_json["has_more"] is False
+    assert response_json["page"] == 1
+    assert response_json["page_size"] == 10
+    assert {str(file_id1), str(file_id2)} == {file["id"] for file in response_json["items"]}
+    assert str(file_id3) not in [file["id"] for file in response_json["items"]]
+    assert all(file["collection"]["id"] == file["collection_id"] for file in response_json["items"])
+    assert all(file["collection"]["name"] for file in response_json["items"])
+
+
+@pytest.mark.asyncio
+async def test_search_files_by_name_endpoint_has_more(test_client, test_admin_user, seed_file, make_jwt, mock_boto3_client):
+    """Test search files by partial name endpoint returns has_more."""
+    test_admin_user_jwt = make_jwt(sub=str(test_admin_user.id))
+    headers = {"Authorization": f"Bearer {test_admin_user_jwt}", "x-active-ngroup-id":test_admin_user.active_ngroup_id}
+    await seed_file(uuid.uuid4(), "granule-alpha.nc", 'application/octet-stream', test_admin_user.id, 1024, status="distributed")
+    await seed_file(uuid.uuid4(), "granule-beta.nc", 'application/octet-stream', test_admin_user.id, 1024, status="clean")
+    params = {"q": "granule", "page": 1, "page_size": 1}
+
+    response = test_client.get("/v2/files/search", headers=headers, params=params)
+    response_json = response.json()
+
+    assert response.status_code == 200
+    assert len(response_json["items"]) == 1
+    assert response_json["has_more"] is True
+
+
+@pytest.mark.asyncio
+async def test_search_files_by_name_endpoint_with_status(test_client, test_admin_user, seed_file, make_jwt, mock_boto3_client):
+    """Test search files by partial name endpoint with status filter."""
+    test_admin_user_jwt = make_jwt(sub=str(test_admin_user.id))
+    headers = {"Authorization": f"Bearer {test_admin_user_jwt}", "x-active-ngroup-id":test_admin_user.active_ngroup_id}
+    distributed_file_id = uuid.uuid4()
+    clean_file_id = uuid.uuid4()
+    await seed_file(distributed_file_id, "granule-alpha.nc", 'application/octet-stream', test_admin_user.id, 1024, status="distributed")
+    await seed_file(clean_file_id, "granule-beta.nc", 'application/octet-stream', test_admin_user.id, 1024, status="clean")
+    params = {"q": "granule", "status": "distributed", "page": 1, "page_size": 10}
+
+    response = test_client.get("/v2/files/search", headers=headers, params=params)
+    response_json = response.json()
+
+    assert response.status_code == 200
+    assert response_json["has_more"] is False
+    assert response_json["items"][0]["id"] == str(distributed_file_id)
+
+
+@pytest.mark.asyncio
 async def test_get_file_endpoint(test_client, test_admin_user, seed_file, make_jwt, mock_boto3_client):
     """Ttest get file endpoint - success."""
     test_admin_user_jwt = make_jwt(sub=str(test_admin_user.id))

--- a/tests/unit_tests/api_utils_unit_tests/test_utils_file.py
+++ b/tests/unit_tests/api_utils_unit_tests/test_utils_file.py
@@ -7,7 +7,8 @@ import os
 
 from app.v2.utils.file import (FileNotFoundError, InvalidApiKeyError, ApiKeyScopeError,
                                ApiKeyConfigurationError, FileAccessError, get_file_details,
-                               find_files_by_name, list_files, list_files_by_api_key, update_file, delete_file)
+                               find_files_by_name, search_files_by_name, list_files,
+                               list_files_by_api_key, update_file, delete_file)
 from app.v2.utils.api_keys import create_api_key
 from app.v2.type_util.file import FileUpdateRequest, FileListRequest 
 from app.v2.type_util.api_keys import ApiKeyCreateRequest
@@ -42,6 +43,53 @@ async def test_find_files_by_name(make_request, seed_file, test_admin_user):
     file = await find_files_by_name(req, test_admin_user, None, mock_file["file"]["name"])
     assert file_id == file[0]["id"]
     assert mock_file["file"]["name"] == file[0]["name"]
+
+@pytest.mark.asyncio
+async def test_search_files_by_name(make_request, seed_file, test_admin_user):
+    """Test searching files by partial name."""
+    req = make_request()
+    file_id1 = uuid.uuid4()
+    file_id2 = uuid.uuid4()
+    file_id3 = uuid.uuid4()
+    await seed_file(file_id1, "granule-alpha.nc", 'application/octet-stream', test_admin_user.id, 1024, status="distributed")
+    await seed_file(file_id2, "granule-beta.nc", 'application/octet-stream', test_admin_user.id, 1024, status="clean")
+    await seed_file(file_id3, "metadata.json", 'application/octet-stream', test_admin_user.id, 1024, status="distributed")
+
+    files, has_more = await search_files_by_name(req, test_admin_user, None, "gran", 1, 15)
+
+    assert has_more is False
+    assert {file_id1, file_id2} == {f["id"] for f in files}
+    assert file_id3 not in [f["id"] for f in files]
+    assert all(file["collection"]["id"] == file["collection_id"] for file in files)
+    assert all(file["collection"]["name"] for file in files)
+
+@pytest.mark.asyncio
+async def test_search_files_by_name_has_more(make_request, seed_file, test_admin_user):
+    """Test searching files fetches one extra row to detect more results."""
+    req = make_request()
+    file_id1 = uuid.uuid4()
+    file_id2 = uuid.uuid4()
+    await seed_file(file_id1, "granule-alpha.nc", 'application/octet-stream', test_admin_user.id, 1024, status="distributed")
+    await seed_file(file_id2, "granule-beta.nc", 'application/octet-stream', test_admin_user.id, 1024, status="clean")
+
+    files, has_more = await search_files_by_name(req, test_admin_user, None, "granule", 1, 1)
+
+    assert len(files) == 1
+    assert has_more is True
+
+@pytest.mark.asyncio
+async def test_search_files_by_name_with_status(make_request, seed_file, test_admin_user):
+    """Test searching files by partial name and status."""
+    req = make_request()
+    distributed_file_id = uuid.uuid4()
+    clean_file_id = uuid.uuid4()
+    await seed_file(distributed_file_id, "granule-alpha.nc", 'application/octet-stream', test_admin_user.id, 1024, status="distributed")
+    await seed_file(clean_file_id, "granule-beta.nc", 'application/octet-stream', test_admin_user.id, 1024, status="clean")
+
+    files, has_more = await search_files_by_name(req, test_admin_user, None, "granule", 1, 15, "distributed")
+
+    assert has_more is False
+    assert files[0]["id"] == distributed_file_id
 
 @pytest.mark.asyncio
 async def test_list_files(make_request, seed_file, test_admin_user):


### PR DESCRIPTION
Added backend support for search-as-you-type file name search.

Changes:
> Added GET /v2/files/search.
> Supports partial filename search through q.
> Supports optional file status filtering through status.
> Uses PostgreSQL pg_trgm with a GIN trigram index on file.name.
> Avoids expensive COUNT(*) during typeahead search.
> Uses page_size + 1 fetching to return has_more.

> Added FileSearchResponse with:
 
> > items
> > has_more
> > page
> > page_size

> Added database utility and API utility search methods.
> Added unit and integration test coverage for:
> > Partial filename search
> > Status-filtered search
> > has_more behavior

> Validation:
 
> > Python compile check passed.
> > Full pytest run was blocked locally because the environment is missing dependencies such as fastapi.