### PR TITLE
Feature: Spam Filter for user rejection

### DIFF
--- a/src/postgres/2-tables.sql
+++ b/src/postgres/2-tables.sql
@@ -227,6 +227,7 @@ CREATE TABLE IF NOT EXISTS user_application (
     justification TEXT NOT NULL,
     account_type account_type,
     edpub_id VARCHAR,
+    is_spam BOOLEAN NOT NULL DEFAULT FALSE,
     PRIMARY KEY (id),
     FOREIGN KEY (ngroup_id) REFERENCES ngroup(id),
     FOREIGN KEY (provider_id) REFERENCES provider(id)
@@ -281,6 +282,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_unique_pending_application ON user_applica
 
 -- Index for admins listing applications by group and status
 CREATE INDEX IF NOT EXISTS idx_user_application_ngroup_status ON user_application(ngroup_id, status);
+CREATE INDEX IF NOT EXISTS idx_user_application_email_spam ON user_application(LOWER(email)) WHERE (is_spam = TRUE);
 
 -- Indexes for common foreign key lookups to speed up JOINs
 CREATE INDEX IF NOT EXISTS idx_file_collection_id ON file(collection_id);

--- a/src/postgres/9-updates.sql
+++ b/src/postgres/9-updates.sql
@@ -45,6 +45,7 @@ BEGIN
             provider_id UUID NULL,  -- Allow NULL initially
             justification TEXT NOT NULL,
             account_type account_type, -- added account type
+            is_spam BOOLEAN NOT NULL DEFAULT FALSE,
             PRIMARY KEY (id),
             FOREIGN KEY (ngroup_id) REFERENCES ngroup(id),
             FOREIGN KEY (provider_id) REFERENCES provider(id) -- Add FK constraint
@@ -57,6 +58,13 @@ ALTER COLUMN applied TYPE TIMESTAMPTZ;
 
 ALTER TABLE user_application
 ADD COLUMN IF NOT EXISTS edpub_id VARCHAR;
+
+ALTER TABLE user_application
+ADD COLUMN IF NOT EXISTS is_spam BOOLEAN NOT NULL DEFAULT FALSE;
+
+CREATE INDEX IF NOT EXISTS idx_user_application_email_spam
+ON user_application(LOWER(email))
+WHERE (is_spam = TRUE);
 
 ALTER TABLE cueuser_auth
 ALTER COLUMN last_login TYPE TIMESTAMPTZ;

--- a/src/python/api/v2/database_util/user_application.py
+++ b/src/python/api/v2/database_util/user_application.py
@@ -14,6 +14,9 @@ logger = structlog.get_logger(__name__)
 
 async def create_user_application(conn: Connection, app_data: UserApplicationCreate, user_id: UUID) -> Dict[str, Any]:
     """Inserts a new user_application record into the database, including the user's Keycloak ID."""
+    if await is_email_spam(conn, str(app_data.email)):
+        raise ValueError("This email has been marked as spam.")
+
     query = """
         INSERT INTO user_application 
             (user_id, email, name, username, justification, ngroup_id, account_type, provider_id, edpub_id, status)
@@ -30,6 +33,18 @@ async def get_user_application_by_id(conn: Connection, application_id: UUID) -> 
     """Retrieves a single user application by its ID."""
     row = await conn.fetchrow("SELECT * FROM user_application WHERE id = $1", application_id)
     return dict(row) if row else None
+
+async def is_email_spam(conn: Connection, email: str) -> bool:
+    """Checks whether an email has previously been marked as spam."""
+    query = """
+        SELECT EXISTS (
+            SELECT 1
+            FROM user_application
+            WHERE LOWER(email) = LOWER($1)
+              AND is_spam = TRUE
+        );
+    """
+    return await conn.fetchval(query, email)
 
 async def get_pending_application_by_user_id(conn: Connection, user_id: UUID) -> Optional[Dict[str, Any]]:
     """
@@ -56,7 +71,7 @@ async def list_user_applications(
 
     user_roles = set(requesting_user.get('roles', []))
     params = []
-    conditions = []
+    conditions = ["is_spam = FALSE"]
     
     # For non-privileged users, explicitly hide applications for the 'ESDIS Security' group.
     # This ensures a DAAC Manager can never see them.
@@ -87,11 +102,35 @@ async def list_user_applications(
     records = await conn.fetch(query, *params)
     return [dict(record) for record in records]
 
-async def update_application_status(conn: Connection, application_id: UUID, status: ApplicationStatus) -> Optional[Dict[str, Any]]:
+async def update_application_status(
+    conn: Connection,
+    application_id: UUID,
+    status: ApplicationStatus,
+    is_spam: Optional[bool] = None
+) -> Optional[Dict[str, Any]]:
     """Updates the status of a user application."""
-    query = "UPDATE user_application SET status = $1 WHERE id = $2 RETURNING *;"
-    row = await conn.fetchrow(query, status.value, application_id)
+    if is_spam is None:
+        query = "UPDATE user_application SET status = $1 WHERE id = $2 RETURNING *;"
+        row = await conn.fetchrow(query, status.value, application_id)
+    else:
+        query = "UPDATE user_application SET status = $1, is_spam = $2 WHERE id = $3 RETURNING *;"
+        row = await conn.fetchrow(query, status.value, is_spam, application_id)
     return dict(row) if row else None
+
+async def mark_email_as_spam(conn: Connection, email: str) -> List[Dict[str, Any]]:
+    """Marks all applications from an email as spam and rejects pending ones."""
+    query = """
+        UPDATE user_application
+        SET is_spam = TRUE,
+            status = CASE
+                WHEN status = 'pending' THEN 'rejected'::application_status
+                ELSE status
+            END
+        WHERE LOWER(email) = LOWER($1)
+        RETURNING *;
+    """
+    records = await conn.fetch(query, email)
+    return [dict(record) for record in records]
 
 async def delete_user_application(conn: Connection, application_id: UUID) -> bool:
     """Deletes a user application by its ID."""

--- a/src/python/api/v2/endpoints/user_application.py
+++ b/src/python/api/v2/endpoints/user_application.py
@@ -31,7 +31,7 @@ async def submit_user_application(
         return UserApplicationResponse.model_validate(new_app)
     except ValueError as e:
         if "spam" in str(e).lower():
-            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="This email address has been marked as spam and is not permitted to submit applications.")
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="This email address is not permitted to submit applications. If you believe this is an error, please contact your Group Representative.")
         if "already exists" in str(e):
             raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="A pending application for this user already exists.")
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))

--- a/src/python/api/v2/endpoints/user_application.py
+++ b/src/python/api/v2/endpoints/user_application.py
@@ -30,6 +30,8 @@ async def submit_user_application(
         new_app = await app_utils.submit_application(request, application_data, claims.id)
         return UserApplicationResponse.model_validate(new_app)
     except ValueError as e:
+        if "spam" in str(e).lower():
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="This email address has been marked as spam and is not permitted to submit applications.")
         if "already exists" in str(e):
             raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="A pending application for this user already exists.")
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
@@ -90,10 +92,14 @@ async def approve_application_endpoint(
 
 
 @router.post("/{application_id}/reject", response_model=UserApplicationResponse, dependencies=[Depends(require_privilege("application:approve"))])
-async def reject_application_endpoint(request: Request, application_id: UUID):
+async def reject_application_endpoint(
+    request: Request,
+    application_id: UUID,
+    mark_as_spam: bool = Query(False, description="Mark the applicant email as spam and block future applications from it.")
+):
     """Rejects a pending user application."""
     try:
-        rejected_app = await app_utils.reject_application(request, application_id)
+        rejected_app = await app_utils.reject_application(request, application_id, mark_as_spam=mark_as_spam)
         return UserApplicationResponse.model_validate(rejected_app)
     except (app_utils.ApplicationNotFoundError, app_utils.ApplicationInvalidStateError) as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))

--- a/src/python/api/v2/type_util/user_application.py
+++ b/src/python/api/v2/type_util/user_application.py
@@ -54,6 +54,7 @@ class UserApplicationResponse(BaseModel):
     account_type: AccountType
     edpub_id: Optional[str] = None
     status: ApplicationStatus
+    is_spam: bool = False
     applied: datetime
 
     class Config:

--- a/src/python/api/v2/utils/user_application.py
+++ b/src/python/api/v2/utils/user_application.py
@@ -149,17 +149,23 @@ async def approve_application(request: Request, application_id: UUID, role_id_to
         logger.error("application.approval.failed", application_id=str(application_id), exc_info=True)
         raise e
 
-async def reject_application(request: Request, application_id: UUID) -> Dict[str, Any]:
-    """Rejects a pending user application."""
-    logger.info("application.rejection.started", application_id=str(application_id))
+async def reject_application(request: Request, application_id: UUID, mark_as_spam: bool = False) -> Dict[str, Any]:
+    """Rejects a pending user application, optionally blocking future requests from the email."""
+    logger.info("application.rejection.started", application_id=str(application_id), mark_as_spam=mark_as_spam)
     async with request.state.pool.acquire() as conn:
         app_data = await app_db.get_user_application_by_id(conn, application_id)
         if not app_data:
             raise ApplicationNotFoundError("Application not found.")
         if app_data['status'] != 'pending':
             raise ApplicationInvalidStateError(f"Application is not in 'pending' state. Current status: {app_data['status']}")
-            
-        updated_app = await app_db.update_application_status(conn, application_id, ApplicationStatus.REJECTED)
-    logger.info("application.rejection.completed", application_id=str(application_id))
+
+        if mark_as_spam:
+            async with conn.transaction():
+                updated_apps = await app_db.mark_email_as_spam(conn, app_data['email'])
+            updated_app = next((app for app in updated_apps if app['id'] == application_id), None)
+        else:
+            updated_app = await app_db.update_application_status(conn, application_id, ApplicationStatus.REJECTED)
+
+    logger.info("application.rejection.completed", application_id=str(application_id), marked_as_spam=mark_as_spam)
     return updated_app
 

--- a/src/python/lambda_utils/database_util/user_application.py
+++ b/src/python/lambda_utils/database_util/user_application.py
@@ -28,6 +28,7 @@ async def get_user_application_from_db(conn: Connection, params: Tuple) -> List:
         SELECT id, email, name, applied, username, status, ngroup_id, provider_id, justification, account_type, edpub_id
         FROM user_application
         WHERE id = $1
+          AND is_spam = FALSE
     """
     query_params: List[Any] = [user_application_id]
     if ngroup_id:
@@ -91,11 +92,12 @@ async def list_user_applications_from_db(conn: Connection, params: Optional[Tupl
     select_query = """
         SELECT id, email, name, applied, username, status, ngroup_id, provider_id, justification, account_type, edpub_id
         FROM user_application
+        WHERE is_spam = FALSE
     """
     query_params: List[Any] = []
     # ngroup_id is the first and only element, if it exists.
     if params and params[0] is not None: # Safely check if params exists and ngroup exists
-        select_query += " WHERE ngroup_id = $1"
+        select_query += " AND ngroup_id = $1"
         query_params.append(params[0])
 
     try:


### PR DESCRIPTION
Adds support for marking user applications as spam and preventing future submissions from previously flagged email addresses.

### Changes

- Added is_spam column to user_application with a default value of false.
- Added a partial index on lowercased spam email addresses for faster spam checks.
- Added mark_as_spam option to the reject application endpoint.
- When an application is rejected as spam:
    - all applications from the same email are marked as spam
    - pending applications from that email are rejected
    - spam applications are hidden from application listing APIs
- Blocks future application submissions from emails previously marked as spam, using case-insensitive matching.
- Includes is_spam in user application API responses.
- Updated lambda-side application queries to exclude spam applications.