### PR TITLE
Feature: Configure collection and provider subfolder in egress 

### DIFF
--- a/src/python/event_lambdas/file_transfer/db.py
+++ b/src/python/event_lambdas/file_transfer/db.py
@@ -22,11 +22,14 @@ async def fetch_batch_transfer_details(conn: Connection, file_ids: List[UUID]) -
             f.collection_path,
             f.size_bytes, 
             f.collection_id,
+            c.short_name as collection_name,
+            u.cueusername as uploader_username,
             f.type,
             e.path as egress_path,
             e.config as egress_config
         FROM file f
         JOIN collection c ON f.collection_id = c.id
+        JOIN cueuser u ON f.cueuser_uploaded = u.id
         JOIN egress e ON c.egress_id = e.id
         WHERE f.id = ANY($1::UUID[])
           AND f.name != 'pending_upload' -- Ensure file has a real name
@@ -43,7 +46,10 @@ async def fetch_batch_transfer_details(conn: Connection, file_ids: List[UUID]) -
                     "checksum": record["checksum"],
                     "collection_path": record["collection_path"],
                     "size_bytes": record["size_bytes"],
-                    "collection_id": record["collection_id"]
+                    "collection_id": record["collection_id"],
+                    "collection_name": record["collection_name"],
+                    "uploader_username": record["uploader_username"],
+                    "type": record["type"]
                 },
                 "egress": {
                     "path": record["egress_path"],

--- a/src/python/event_lambdas/file_transfer/logic.py
+++ b/src/python/event_lambdas/file_transfer/logic.py
@@ -4,6 +4,7 @@ from botocore.exceptions import ClientError
 from uuid import UUID
 import json
 import os
+import posixpath
 from typing import Dict, List, Any, Optional, Tuple
 import structlog
 import asyncpg
@@ -122,6 +123,21 @@ async def copy_file_to_dest(src_key: str, dest_bucket: str, dest_key: str, file_
                 logger.error("s3.copy.failed.persistent_error", src_key=src_key, dest_key=dest_key, error_code=e.response['Error']['Code'])
                 raise
 
+def build_destination_key(egress_config: Dict[str, Any], file_info: Dict[str, Any]) -> str:
+    """Builds the destination S3 key from egress config and file metadata."""
+    path_parts = [egress_config.get("destination_path")]
+    create_collection_subfolder = str(egress_config.get("create_collection_subfolder", "")).lower() == "true"
+    prefix_username = str(egress_config.get("prefix_username", "")).lower() == "true"
+
+    if create_collection_subfolder:
+        path_parts.append(file_info.get("collection_name"))
+
+    if prefix_username:
+        path_parts.append(file_info.get("uploader_username"))
+
+    path_parts.extend([file_info.get("collection_path"), file_info["name"]])
+    return posixpath.join(*[str(p) for p in path_parts if p])
+
 async def add_tags_to_dest(dest_bucket: str, dest_key: str, file_id: str):
     """Applies the file_id and checksum as S3 object tags to the destination file."""
     
@@ -165,15 +181,15 @@ async def batch_transfer_and_validate(
 
         file_info = details["file_info"]
         egress = details["egress"]
-        dest_bucket = egress.get("config", {}).get("bucket")
+        egress_config = egress.get("config", {})
+        dest_bucket = egress_config.get("bucket")
 
         if not dest_bucket:
             logger.error("batch_transfer.failed.no_destination_bucket", file_id=str(file_id), message_id=message_id)
             hard_failures.append({"itemIdentifier": message_id})
             continue
 
-        path_parts = [p for p in [egress.get("config", {}).get("destination_path"), file_info.get("collection_path"), file_info["name"]] if p]
-        dest_key = os.path.join(*path_parts)
+        dest_key = build_destination_key(egress_config, file_info)
 
         try:
             await copy_file_to_dest(str(file_id), dest_bucket, dest_key, file_info)


### PR DESCRIPTION
What changed
- Expanded the batch transfer metadata query to fetch:
      collection_name
      uploader_username
- Included these fields in the returned file_info payload.
- 
Added build_destination_key() helper to construct S3 destination keys consistently using posixpath.join().
- Added support for:
      create_collection_subfolder -> adds collection name folder
      prefix_username -> adds uploader username folder
- Updated transfer flow to use the new helper and a single resolved egress_config.