### PR TITLE
Feature: List Spam applications & unmark Spam applications

### DIFF
--- a/src/python/api/v2/database_util/cueuser.py
+++ b/src/python/api/v2/database_util/cueuser.py
@@ -34,6 +34,12 @@ async def get_user_by_id(conn: Connection, user_id: UUID) -> Optional[Dict[str, 
                 WHERE ug.cueuser_id = u.id
             ) AS ngroups,
             (
+                SELECT COALESCE(jsonb_agg(jsonb_build_object('id', p.id, 'short_name', p.short_name)), '[]'::jsonb)
+                FROM cueuser_provider up
+                JOIN provider p ON up.provider_id = p.id
+                WHERE up.cueuser_id = u.id
+            ) AS providers,
+            (
                 SELECT COALESCE(jsonb_agg(DISTINCT p.privilege), '[]'::jsonb)
                 FROM cueuser_role ur
                 JOIN role_privilege rp ON ur.role_id = rp.role_id
@@ -81,6 +87,11 @@ async def list_users(
                 WHERE ug.cueuser_id = u.id
             ) AS ngroups,
             (
+                SELECT COALESCE(jsonb_agg(jsonb_build_object('id', p.id, 'short_name', p.short_name)), '[]'::jsonb)
+                FROM cueuser_provider up JOIN provider p ON up.provider_id = p.id
+                WHERE up.cueuser_id = u.id
+            ) AS providers,
+            (
                 SELECT COALESCE(jsonb_agg(DISTINCT p.privilege), '[]'::jsonb)
                 FROM cueuser_role ur
                 JOIN role_privilege rp ON ur.role_id = rp.role_id
@@ -118,19 +129,36 @@ async def list_users(
 
 async def get_user_by_username(conn: Connection, cueusername: str) -> Optional[Dict[str, Any]]:
     """Fetches a single user's core data by their unique username."""
-    # This query is simple enough that it doesn't need the subquery optimization.
     query = """
         SELECT
             u.id, u.email, u.name, u.cueusername, u.edpub_id, u.registered,
-            COALESCE(jsonb_agg(DISTINCT r.short_name) FILTER (WHERE r.short_name IS NOT NULL), '[]'::jsonb) AS roles,
-            COALESCE(jsonb_agg(DISTINCT g.short_name) FILTER (WHERE g.short_name IS NOT NULL), '[]'::jsonb) AS ngroups
+            (
+                SELECT COALESCE(jsonb_agg(r.short_name), '[]'::jsonb)
+                FROM cueuser_role ur
+                JOIN role r ON ur.role_id = r.id
+                WHERE ur.cueuser_id = u.id
+            ) AS roles,
+            (
+                SELECT COALESCE(jsonb_agg(jsonb_build_object('id', g.id, 'short_name', g.short_name)), '[]'::jsonb)
+                FROM cueuser_ngroup ug
+                JOIN ngroup g ON ug.ngroup_id = g.id
+                WHERE ug.cueuser_id = u.id
+            ) AS ngroups,
+            (
+                SELECT COALESCE(jsonb_agg(jsonb_build_object('id', p.id, 'short_name', p.short_name)), '[]'::jsonb)
+                FROM cueuser_provider up
+                JOIN provider p ON up.provider_id = p.id
+                WHERE up.cueuser_id = u.id
+            ) AS providers,
+            (
+                SELECT COALESCE(jsonb_agg(DISTINCT p.privilege), '[]'::jsonb)
+                FROM cueuser_role ur
+                JOIN role_privilege rp ON ur.role_id = rp.role_id
+                JOIN privilege p ON rp.privilege_id = p.id
+                WHERE ur.cueuser_id = u.id
+            ) AS privileges
         FROM cueuser u
-        LEFT JOIN cueuser_role ur ON u.id = ur.cueuser_id
-        LEFT JOIN role r ON ur.role_id = r.id
-        LEFT JOIN cueuser_ngroup ug ON u.id = ug.cueuser_id
-        LEFT JOIN ngroup g ON ug.ngroup_id = g.id
-        WHERE u.cueusername = $1
-        GROUP BY u.id;
+        WHERE u.cueusername = $1;
     """
     return await conn.fetchrow(query, cueusername)
 

--- a/src/python/api/v2/database_util/user_application.py
+++ b/src/python/api/v2/database_util/user_application.py
@@ -41,7 +41,7 @@ async def is_email_spam(conn: Connection, email: str) -> bool:
             SELECT 1
             FROM user_application
             WHERE LOWER(email) = LOWER($1)
-              AND is_spam = TRUE
+              AND is_spam = TRUE ORDER BY applied DESC LIMIT 1
         );
     """
     return await conn.fetchval(query, email)
@@ -60,7 +60,7 @@ async def list_user_applications(
     requesting_user: Dict[str, Any],
     active_ngroup_id: Optional[UUID] = None,
     status: Optional[ApplicationStatus] = None,
-    is_spam: bool = False
+    is_spam: Optional[bool] = None
 ) -> List[Dict[str, Any]]:
     """Lists user applications, filtered by the active ngroup and user role."""
     logger.info(
@@ -73,8 +73,10 @@ async def list_user_applications(
 
     user_roles = set(requesting_user.get('roles', []))
     params = []
-    params.append(is_spam)
-    conditions = [f"is_spam = ${len(params)}"]
+    conditions = []
+    if is_spam is not None:
+        params.append(is_spam)
+        conditions.append(f"is_spam = ${len(params)}")
     
     # For non-privileged users, explicitly hide applications for the 'ESDIS Security' group.
     # This ensures a DAAC Manager can never see them.

--- a/src/python/api/v2/database_util/user_application.py
+++ b/src/python/api/v2/database_util/user_application.py
@@ -39,9 +39,14 @@ async def is_email_spam(conn: Connection, email: str) -> bool:
     query = """
         SELECT EXISTS (
             SELECT 1
-            FROM user_application
-            WHERE LOWER(email) = LOWER($1)
-              AND is_spam = TRUE ORDER BY applied DESC LIMIT 1
+            FROM (
+                SELECT is_spam
+                FROM user_application
+                WHERE LOWER(email) = LOWER($1)
+                ORDER BY applied DESC
+                LIMIT 1
+            ) latest_application
+            WHERE is_spam = TRUE
         );
     """
     return await conn.fetchval(query, email)

--- a/src/python/api/v2/endpoints/user_application.py
+++ b/src/python/api/v2/endpoints/user_application.py
@@ -45,7 +45,7 @@ async def list_all_applications(
     # Read the active ngroup ID directly from the header
     active_ngroup_id: Optional[str] = Header(None, alias="x-active-ngroup-id"),
     application_status: Optional[ApplicationStatus] = Query(None, alias="status", description="Filter applications by status."),
-    is_spam: bool = Query(False, alias="is-spam", description="Filter applications by spam flag.")
+    is_spam: Optional[bool] = Query(None, alias="is-spam", description="Filter applications by spam flag.")
 ):
     """
     Lists user applications, filtered by the selected ngroup. Admins see all,

--- a/src/python/api/v2/endpoints/user_application.py
+++ b/src/python/api/v2/endpoints/user_application.py
@@ -104,3 +104,15 @@ async def reject_application_endpoint(
         return UserApplicationResponse.model_validate(rejected_app)
     except (app_utils.ApplicationNotFoundError, app_utils.ApplicationInvalidStateError) as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+
+@router.post("/{application_id}/unmark-spam", response_model=UserApplicationResponse, dependencies=[Depends(require_privilege("application:approve"))])
+async def unmark_spam_application_endpoint(
+    request: Request,
+    application_id: UUID
+):
+    """Unmarks a user application as spam, keeping the status as rejected and setting is_spam to False."""
+    try:
+        updated_app = await app_utils.unmark_spam_application(request, application_id)
+        return UserApplicationResponse.model_validate(updated_app)
+    except (app_utils.ApplicationNotFoundError, app_utils.ApplicationInvalidStateError) as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))

--- a/src/python/api/v2/type_util/cueuser.py
+++ b/src/python/api/v2/type_util/cueuser.py
@@ -5,6 +5,7 @@ from uuid import UUID
 from datetime import datetime
 from pydantic import BaseModel, Field, EmailStr
 from .ngroup import NgroupListResponse
+from .provider import ProviderListResponse
 
 # --- User Profile & List Models ---
 
@@ -19,6 +20,7 @@ class UserResponse(BaseModel):
     registered: datetime
     roles: List[str] = Field(default_factory=list, description="List of role short names.")
     ngroups: List[NgroupListResponse] = Field(default_factory=list, description="List of ngroup objects the user belongs to.")
+    providers: List[ProviderListResponse] = Field(default_factory=list, description="List of provider objects the user belongs to.")
     privileges: List[str] = Field(default_factory=list, description="Consolidated list of all permissions.")
     
     class Config:

--- a/src/python/api/v2/utils/cueuser.py
+++ b/src/python/api/v2/utils/cueuser.py
@@ -25,7 +25,7 @@ def _parse_user_data(user_data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     
     parsed_data = dict(user_data)
     
-    for key in ["roles", "ngroups", "privileges"]:
+    for key in ["roles", "ngroups", "privileges", "providers"]:
         if isinstance(parsed_data.get(key), str):
             try:
                 parsed_data[key] = json.loads(parsed_data[key])

--- a/src/python/api/v2/utils/user_application.py
+++ b/src/python/api/v2/utils/user_application.py
@@ -170,3 +170,21 @@ async def reject_application(request: Request, application_id: UUID, mark_as_spa
 
     logger.info("application.rejection.completed", application_id=str(application_id), marked_as_spam=mark_as_spam)
     return updated_app
+
+async def unmark_spam_application(request: Request, application_id: UUID) -> Dict[str, Any]:
+    """Unmarks a user application as spam, keeping the status as rejected and setting is_spam to False."""
+    logger.info("application.unmark_spam.started", application_id=str(application_id))
+    async with request.state.pool.acquire() as conn:
+        app_data = await app_db.get_user_application_by_id(conn, application_id)
+        if not app_data:
+            raise ApplicationNotFoundError("Application not found.")
+        
+        updated_app = await app_db.update_application_status(
+            conn,
+            application_id,
+            ApplicationStatus.REJECTED,
+            is_spam=False
+        )
+
+    logger.info("application.unmark_spam.completed", application_id=str(application_id))
+    return updated_app

--- a/src/python/api/v2/utils/user_application.py
+++ b/src/python/api/v2/utils/user_application.py
@@ -59,7 +59,7 @@ async def list_applications(
     user: User, # Accept the full user object for role checks
     active_ngroup_id: Optional[str] = None, # Accept the optional ngroup ID string
     status: Optional[ApplicationStatus] = None,
-    is_spam: bool = False
+    is_spam: Optional[bool] = None
 ) -> List[Dict[str, Any]]:
     """Lists all applications based on user roles and optional filters."""
 

--- a/src/python/api/v2/utils/user_application.py
+++ b/src/python/api/v2/utils/user_application.py
@@ -166,7 +166,8 @@ async def reject_application(request: Request, application_id: UUID, mark_as_spa
                 updated_apps = await app_db.mark_email_as_spam(conn, app_data['email'])
             updated_app = next((app for app in updated_apps if app['id'] == application_id), None)
         else:
-            updated_app = await app_db.update_application_status(conn, application_id, ApplicationStatus.REJECTED)
+            await app_db.delete_user_application(conn, application_id)
+            updated_app = {**app_data, 'status': ApplicationStatus.REJECTED, 'is_spam': False}
 
     logger.info("application.rejection.completed", application_id=str(application_id), marked_as_spam=mark_as_spam)
     return updated_app
@@ -179,12 +180,8 @@ async def unmark_spam_application(request: Request, application_id: UUID) -> Dic
         if not app_data:
             raise ApplicationNotFoundError("Application not found.")
         
-        updated_app = await app_db.update_application_status(
-            conn,
-            application_id,
-            ApplicationStatus.REJECTED,
-            is_spam=False
-        )
+        await app_db.delete_user_application(conn, application_id)
+        updated_app = {**app_data, 'status': ApplicationStatus.REJECTED, 'is_spam': False}
 
     logger.info("application.unmark_spam.completed", application_id=str(application_id))
     return updated_app


### PR DESCRIPTION
- Added spam filtering support for user application listing:
        list_applications and list_user_applications now accept an optional is_spam filter.
        GET /... endpoint now exposes is-spam query parameter.
- Improved spam detection logic for email lookups:
        is_email_spam now checks only the latest application record for an email by applied DESC LIMIT 1.
- Added an unmark-spam workflow:
        New endpoint POST /{application_id}/unmark-spam
        Privilege restricted to application:approve
        Unmarks spam applications while preserving rejected state and is_spam=False
- Adjusted rejection handling in utilities:
        Existing reject flow now deletes the application record and returns a normalized rejected response when not marking as spam.
- Provider join to view in users page