### PR TITLE
Feature: Support to update provider

### DIFF
--- a/src/python/api/v2/endpoints/cueuser.py
+++ b/src/python/api/v2/endpoints/cueuser.py
@@ -127,7 +127,7 @@ async def update_user_role_endpoint(
 ):
     """Assigns a new role to a user."""
     try:
-        updated_user = await cueuser_utils.update_user_role(request, user_id, update_req.role_id, current_user)
+        updated_user = await cueuser_utils.update_user_role(request, user_id, update_req.role_id, current_user, provider_id=update_req.provider_id)
         return UserResponse.model_validate(updated_user)
     except cueuser_utils.UserNotFoundError:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found.")

--- a/src/python/api/v2/type_util/cueuser.py
+++ b/src/python/api/v2/type_util/cueuser.py
@@ -61,6 +61,7 @@ class UserUpdateRequest(BaseModel):
 class UserRoleUpdateRequest(BaseModel):
     """Request body for updating a user's role."""
     role_id: UUID
+    provider_id: Optional[UUID] = None
 
 class PaginatedUserResponse(BaseModel):
     users: List[UserResponse]

--- a/src/python/api/v2/utils/cueuser.py
+++ b/src/python/api/v2/utils/cueuser.py
@@ -170,7 +170,7 @@ async def update_user_details(request: Request, user_id: UUID, update_request: U
     return await get_user_profile(request, user_id)
 
 
-async def update_user_role(request: Request, user_id: UUID, role_id: UUID, current_user: AuthUser) -> Dict[str, Any]:
+async def update_user_role(request: Request, user_id: UUID, role_id: UUID, current_user: AuthUser, provider_id: Optional[UUID] = None) -> Dict[str, Any]:
     """
     Updates a user's role after performing permission checks.
     For simplicity in this system, it replaces all existing roles with the new one.
@@ -178,12 +178,12 @@ async def update_user_role(request: Request, user_id: UUID, role_id: UUID, curre
     is_admin = "admin" in current_user.roles
     is_manager = "daac_manager" in current_user.roles
     
-    if not is_admin:
-        async with request.state.pool.acquire() as conn:
-            target_role = await role_db.get_role_by_id(conn, role_id)
-            if not target_role:
-                raise ValueError("Target role not found.")
+    async with request.state.pool.acquire() as conn:
+        target_role = await role_db.get_role_by_id(conn, role_id)
+        if not target_role:
+            raise ValueError("Target role not found.")
 
+        if not is_admin:
             allowed_roles = set()
             if is_manager:
                 # --- Add 'daac_manager' to the list of assignable roles ---
@@ -195,8 +195,14 @@ async def update_user_role(request: Request, user_id: UUID, role_id: UUID, curre
             if target_role['short_name'] not in allowed_roles:
                 raise ValueError("You do not have permission to assign this role.")
 
-    async with request.state.pool.acquire() as conn:
-        await user_db.update_user_roles(conn, user_id, [role_id])
+        async with request.state.pool.acquire() as conn:
+            await user_db.update_user_roles(conn, user_id, [role_id])
+            if target_role['short_name'] == 'provider':
+                await conn.execute("DELETE FROM cueuser_provider WHERE cueuser_id = $1", user_id)
+                if provider_id:
+                    await conn.execute("INSERT INTO cueuser_provider (cueuser_id, provider_id) VALUES ($1, $2)", user_id, provider_id)
+            else:
+                await conn.execute("DELETE FROM cueuser_provider WHERE cueuser_id = $1", user_id)
     
     logger.info("user.role.updated", user_id=str(user_id), new_role_id=str(role_id), updater_id=str(current_user.id))
     # Fetch the final profile. This is now fast due to the optimized database query.


### PR DESCRIPTION
Changes

- Type Utilities (type_util/cueuser.py):
Added the optional provider_id field to UserRoleUpdateRequest schema to accept the chosen provider ID from role assignment payloads.

- Business Logic (utils/cueuser.py):
Updated update_user_role to receive provider_id and run an atomic update:
If role is set to provider, the user's provider mapping is cleared and updated to the specified provider_id.
If set to any other role, all associated provider mappings are removed.

- API Endpoint Route (endpoints/cueuser.py):
Updated update_user_role_endpoint to pass provider_id parameter to the utility layer helper.